### PR TITLE
refactor: architectural audit + Wave 1 migration (split handlers, runtime primitives, decoupled transport)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ bun.lock
 # Local development
 TODO.md
 .luarc.json
+REVIEW.md
 
 # MkDocs build output
 site/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ bun.lock
 TODO.md
 .luarc.json
 REVIEW.md
+git-journal.md
+tmp/
 
 # MkDocs build output
 site/

--- a/README.md
+++ b/README.md
@@ -61,26 +61,36 @@ git clone https://github.com/arismoko/buddy.nvim ~/.local/share/nvim/site/pack/p
 
 ---
 
-## Connecting to MCP Clients
+## Connecting MCP Clients
 
-nvim-buddy uses **HTTP + Server-Sent Events (SSE)** transport, compatible with modern MCP clients.
+buddy.nvim uses **HTTP + Server-Sent Events (SSE)** transport, compatible with modern MCP clients.
 
-### OpenCode
+There are two ways to connect:
+
+### Option A: Via Proxy (Recommended)
+
+The [`buddy-mcp-proxy`](https://www.npmjs.com/package/buddy-mcp-proxy) automatically discovers running Neovim sessions and supports switching between multiple instances. No port configuration needed. Requires [Node.js](https://nodejs.org/) 20+.
+
+```bash
+npm install -g buddy-mcp-proxy
+```
+
+#### OpenCode
 
 Add to `~/.config/opencode/opencode.jsonc`:
 
 ```jsonc
 {
   "mcp": {
-    "buddy": {
-      "type": "remote",
-      "url": "http://127.0.0.1:7234/sse"
+    "vim": {
+      "type": "local",
+      "command": ["npx", "buddy-mcp-proxy"]
     }
   }
 }
 ```
 
-### Claude Desktop
+#### Claude Desktop
 
 Add to your Claude Desktop config:
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -90,7 +100,37 @@ Add to your Claude Desktop config:
 ```json
 {
   "mcpServers": {
-    "buddy": {
+    "vim": {
+      "command": "npx",
+      "args": ["buddy-mcp-proxy"]
+    }
+  }
+}
+```
+
+### Option B: Direct SSE Connection
+
+Connect directly to a specific Neovim instance by URL. Simpler, but you must know the port and can only connect to one session.
+
+#### OpenCode
+
+```jsonc
+{
+  "mcp": {
+    "vim": {
+      "type": "remote",
+      "url": "http://127.0.0.1:7234/sse"
+    }
+  }
+}
+```
+
+#### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "vim": {
       "url": "http://127.0.0.1:7234/sse"
     }
   }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,22 +56,32 @@
 
 buddy.nvim uses **HTTP + Server-Sent Events (SSE)** transport, compatible with modern MCP clients.
 
-### OpenCode
+There are two ways to connect:
+
+### Option A: Via Proxy (Recommended)
+
+The [`buddy-mcp-proxy`](https://www.npmjs.com/package/buddy-mcp-proxy) automatically discovers running Neovim sessions and supports switching between multiple instances. No port configuration needed.
+
+```bash
+npm install -g buddy-mcp-proxy
+```
+
+#### OpenCode
 
 Add to `~/.config/opencode/opencode.jsonc`:
 
 ```jsonc
 {
   "mcp": {
-    "buddy": {
-      "type": "remote",
-      "url": "http://127.0.0.1:7234/sse"
+    "vim": {
+      "type": "local",
+      "command": ["npx", "buddy-mcp-proxy"]
     }
   }
 }
 ```
 
-### Claude Desktop
+#### Claude Desktop
 
 Add to your Claude Desktop config:
 
@@ -84,7 +94,37 @@ Add to your Claude Desktop config:
 ```json
 {
   "mcpServers": {
-    "buddy": {
+    "vim": {
+      "command": "npx",
+      "args": ["buddy-mcp-proxy"]
+    }
+  }
+}
+```
+
+### Option B: Direct SSE Connection
+
+Connect directly to a specific Neovim instance by URL. Simpler, but you must know the port and can only connect to one session.
+
+#### OpenCode
+
+```jsonc
+{
+  "mcp": {
+    "vim": {
+      "type": "remote",
+      "url": "http://127.0.0.1:7234/sse"
+    }
+  }
+}
+```
+
+#### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "vim": {
       "url": "http://127.0.0.1:7234/sse"
     }
   }

--- a/lua/buddy/config.lua
+++ b/lua/buddy/config.lua
@@ -8,6 +8,7 @@ local defaults = {
   host = "127.0.0.1",  -- Loopback only by default for security
   port = 7234,
   auto_start = false,
+  auth = true,  -- Require Bearer token auth on HTTP endpoints (recommended)
   watch = true,  -- Enable hot reload file watching
   log_level = "info",
   tools = {

--- a/lua/buddy/init.lua
+++ b/lua/buddy/init.lua
@@ -21,6 +21,27 @@ local M = {}
 
 M._server = nil
 M._actual_port = nil
+M._runtime = nil
+
+--- Get or lazily create the runtime primitives (event bus, stores)
+---
+--- Returns a table with event_bus, session_store, and request_store instances.
+--- Created once and reused for the lifetime of the server.
+---
+---@return table runtime { event_bus: BuddyEventBus, session_store: SessionStore, request_store: RequestStore }
+function M.runtime()
+  if not M._runtime then
+    local EventBus = require("buddy.runtime.event_bus")
+    local SessionStore = require("buddy.runtime.state.session_store")
+    local RequestStore = require("buddy.runtime.state.request_store")
+    M._runtime = {
+      event_bus = EventBus.new(),
+      session_store = SessionStore.new(),
+      request_store = RequestStore.new(),
+    }
+  end
+  return M._runtime
+end
 
 --- Setup buddy with the given options
 ---
@@ -142,6 +163,9 @@ function M.stop()
     M._server = nil
     M._actual_port = nil
   end
+
+  -- Reset runtime singletons so next start() gets fresh state
+  M._runtime = nil
 
   require("buddy.tools").clear()
 end

--- a/lua/buddy/init.lua
+++ b/lua/buddy/init.lua
@@ -28,6 +28,7 @@ M._actual_port = nil
 ---@field host string Server host (default: "127.0.0.1")
 ---@field port number Server port (default: 7234)
 ---@field auto_start boolean Start server automatically (default: false)
+---@field auth boolean Enable Bearer token auth on HTTP endpoints (default: true)
 ---@field watch boolean Enable hot reload file watching (default: true)
 ---@field debug boolean Enable debug logging (default: false)
 ---@field tools table Tool configuration
@@ -92,6 +93,19 @@ function M.start()
   local config = require("buddy.config")
   local cfg = config.get()
 
+  -- Generate auth token if auth is enabled
+  local auth_token = nil
+  if cfg.auth then
+    local uv = vim.uv
+    -- Generate a cryptographically-sufficient random token from hrtime + pid + random
+    local raw = string.format("%s:%s:%s:%s", uv.hrtime(), vim.fn.getpid(), math.random(1e9), uv.hrtime())
+    auth_token = vim.fn.sha256(raw)
+  end
+
+  -- Set auth token on router before starting server so it's ready for first connection
+  local router = require("buddy.server.router")
+  router.set_auth_token(auth_token)
+
   local actual_port = server.start(cfg.host, cfg.port)
   M._server = server.get()
   M._actual_port = actual_port
@@ -102,6 +116,7 @@ function M.start()
   sessions.register({
     port = actual_port,
     host = cfg.host,
+    auth_token = auth_token,
   })
 
   -- Start hot reload watching if enabled

--- a/lua/buddy/init.lua
+++ b/lua/buddy/init.lua
@@ -54,14 +54,30 @@ function M.start()
   registry.load_builtins()
 
   -- Add each tool subdirectory to runtimepath (not just the parent)
+  -- and source their plugin files (since we're past startup)
   local default_tools_dir = vim.fn.stdpath("data") .. "/buddy-tools"
   if vim.fn.isdirectory(default_tools_dir) == 1 then
     local rtp = vim.o.runtimepath
     for name, type in vim.fs.dir(default_tools_dir) do
       if type == "directory" then
         local tool_path = default_tools_dir .. "/" .. name
-        if not rtp:find(tool_path, 1, true) then
+        local is_new = not rtp:find(tool_path, 1, true)
+        if is_new then
           vim.o.runtimepath = vim.o.runtimepath .. "," .. tool_path
+        end
+        -- Source plugin files (Neovim doesn't auto-load after startup)
+        if is_new then
+          local plugin_dir = tool_path .. "/plugin"
+          if vim.fn.isdirectory(plugin_dir) == 1 then
+            for pname, ptype in vim.fs.dir(plugin_dir) do
+              if ptype == "file" and pname:match("%.lua$") then
+                local ok, err = pcall(vim.cmd.source, plugin_dir .. "/" .. pname)
+                if not ok then
+                  vim.notify("[buddy] Failed to source " .. pname .. ": " .. tostring(err), vim.log.levels.WARN)
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/lua/buddy/log.lua
+++ b/lua/buddy/log.lua
@@ -60,7 +60,10 @@ local function log(level, msg, ...)
     return
   end
 
-  local formatted = string.format(msg, ...)
+  local ok_fmt, formatted = pcall(string.format, msg, ...)
+  if not ok_fmt then
+    formatted = msg
+  end
 
   maybe_notify(LEVEL_NAMES[level]:lower(), formatted)
 

--- a/lua/buddy/mcp/client_requests.lua
+++ b/lua/buddy/mcp/client_requests.lua
@@ -1,27 +1,29 @@
--- Client Requests: Server-to-client request/response handling
--- Enables sampling, elicitation, and roots requests
+-- Client Requests: Compatibility wrapper delegating to services/client_requester
+-- Preserves existing API for callers (roots.lua, sampling.lua, elicitation.lua)
 
 local M = {}
 
--- Pending requests keyed by request ID
-local pending = {}
-local next_id = 1
+-- Lazily initialized singleton requester backed by SSE transport
+local _requester = nil
 
----@class PendingRequest
----@field resolve fun(result: any)
----@field reject fun(error: any)
----@field timer userdata|nil
----@field session_id string
+--- Get or create the singleton ClientRequester wired to SSE transport
+---@return table ClientRequester instance
+local function get_requester()
+  if not _requester then
+    local ClientRequester = require("buddy.services.client_requester")
+    local SSEHub = require("buddy.transport.sse.hub")
+    local hub = SSEHub.get_instance()
 
---- Generate unique request ID
----@return string
-local function generate_id()
-  local id = "srv_" .. next_id
-  next_id = next_id + 1
-  return id
+    _requester = ClientRequester.new({
+      send_fn = function(session_id, msg)
+        return hub:send_to_session(session_id, msg)
+      end,
+    })
+  end
+  return _requester
 end
 
---- Send a request to client and return a promise-like table
+--- Send a request to client and wait for response
 ---@param session_id string
 ---@param method string
 ---@param params table
@@ -29,124 +31,32 @@ end
 ---@return any result
 ---@return string|nil error
 function M.request(session_id, method, params, timeout_ms)
-  timeout_ms = timeout_ms or 30000
-  
-  -- Get SSE connection for this session
-  local sse = require("buddy.server.sse")
-  local manager = sse.SSEManager.get_instance()
-  local conn = manager:get_session(session_id)
-  
-  if not conn then
-    return nil, "Session not found: " .. session_id
-  end
-  
-  local id = generate_id()
-  local result, err
-  local done = false
-  
-  -- Create pending request entry
-  pending[id] = {
-    session_id = session_id,
-    resolve = function(res)
-      result = res
-      done = true
-    end,
-    reject = function(e)
-      err = e
-      done = true
-    end,
-    timer = nil,
-  }
-  
-  -- Set timeout
-  pending[id].timer = vim.uv.new_timer()
-  pending[id].timer:start(timeout_ms, 0, vim.schedule_wrap(function()
-    if pending[id] then
-      pending[id].reject({ code = -32000, message = "Request timeout" })
-      M.cleanup(id)
-    end
-  end))
-  
-  -- Send request via SSE
-  local request = {
-    jsonrpc = "2.0",
-    id = id,
-    method = method,
-    params = params or {},
-  }
-  
-  local ok = conn:send_data(request)
-  if not ok then
-    M.cleanup(id)
-    return nil, "Failed to send request"
-  end
-  
-  -- Block until response or timeout
-  vim.wait(timeout_ms + 100, function() return done end, 10)
-  
-  if not done then
-    M.cleanup(id)
-    return nil, "Request timeout"
-  end
-  
-  return result, err
-end
-
---- Resolve a pending request (called when client response arrives)
----@param id string Request ID
----@param result any
-function M.resolve(id, result)
-  local req = pending[id]
-  if req then
-    req.resolve(result)
-    M.cleanup(id)
-  end
-end
-
---- Reject a pending request (called when client error arrives)
----@param id string Request ID  
----@param error any
-function M.reject(id, error)
-  local req = pending[id]
-  if req then
-    req.reject(error)
-    M.cleanup(id)
-  end
+  return get_requester():request_sync(session_id, method, params, timeout_ms)
 end
 
 --- Check if a message is a response to a pending request
 ---@param msg table JSON-RPC message
 ---@return boolean
 function M.is_response(msg)
-  local log = require("buddy.log")
-  local is_resp = msg.id and pending[msg.id] ~= nil
-  if msg.id and not msg.method then
-    log.debug("Checking response: id=%s, pending=%s, is_response=%s", 
-      tostring(msg.id), pending[msg.id] and "yes" or "no", tostring(is_resp))
+  if not _requester then
+    return false
   end
-  return is_resp
+  return _requester:is_response(msg)
 end
 
 --- Handle a response message
 ---@param msg table JSON-RPC response
 function M.handle_response(msg)
-  if msg.error then
-    M.reject(msg.id, msg.error)
-  else
-    M.resolve(msg.id, msg.result)
+  if _requester then
+    _requester:handle_response(msg)
   end
 end
 
---- Cleanup a pending request
----@param id string
-function M.cleanup(id)
-  local req = pending[id]
-  if req then
-    if req.timer then
-      req.timer:stop()
-      req.timer:close()
-    end
-    pending[id] = nil
+--- Cleanup pending requests for a session
+---@param session_id string
+function M.cleanup_session(session_id)
+  if _requester then
+    _requester:cleanup_session(session_id)
   end
 end
 
@@ -182,6 +92,11 @@ end
 ---@return string|nil error
 function M.elicitation_create(session_id, params)
   return M.request(session_id, "elicitation/create", params, 120000)
+end
+
+--- Reset internal state (for testing)
+function M._reset()
+  _requester = nil
 end
 
 return M

--- a/lua/buddy/mcp/init.lua
+++ b/lua/buddy/mcp/init.lua
@@ -1,57 +1,8 @@
 local M = {}
-local methods = require("buddy.mcp.methods")
-local schema = require("buddy.mcp.schema")
-
-local function validate_request(request)
-  if type(request) ~= "table" then
-    return false, "Request must be a JSON object"
-  end
-
-  if request.jsonrpc ~= "2.0" then
-    return false, "Missing or invalid jsonrpc version (must be '2.0')"
-  end
-
-  if not request.method then
-    return false, "Missing 'method' field"
-  end
-
-  return true, nil
-end
+local dispatcher = require("buddy.protocol.mcp.dispatcher")
 
 function M.handle_request(session_id, request)
-  local valid, err = validate_request(request)
-  if not valid then
-    if request.id then
-      return schema.error(request.id, -32600, "Invalid Request", err)
-    end
-    return nil
-  end
-
-  local is_notification = request.id == nil
-
-  local method_handler = methods[request.method]
-
-  if not method_handler then
-    if is_notification then
-      return nil
-    end
-    return schema.error(request.id, -32601, "Method not found", "Unknown method: " .. request.method)
-  end
-
-  local ok, result = pcall(method_handler, session_id, request.params or {}, request.id)
-
-  if not ok then
-    if is_notification then
-      return nil
-    end
-    return schema.error(request.id, -32603, "Internal error", tostring(result))
-  end
-
-  if is_notification then
-    return nil
-  end
-
-  return schema.result(request.id, result)
+  return dispatcher.handle_request(session_id, request)
 end
 
 return M

--- a/lua/buddy/mcp/methods.lua
+++ b/lua/buddy/mcp/methods.lua
@@ -1,11 +1,34 @@
+--- MCP Methods — Compatibility Facade
+--- Re-exports handlers from protocol/mcp/handlers/* and content helpers from protocol/mcp/content.lua
+--- This module exists for backward compatibility. New code should use:
+---   require("buddy.protocol.mcp.registry") for handler lookup
+---   require("buddy.protocol.mcp.content") for content constructors
 local M = {}
-local tools = require("buddy.tools")
-local executor = require("buddy.tools.executor")
 
+-- Load all handler modules (they self-register into the registry)
+require("buddy.protocol.mcp.handlers.core")
+require("buddy.protocol.mcp.handlers.tools")
+require("buddy.protocol.mcp.handlers.resources")
+require("buddy.protocol.mcp.handlers.prompts")
+require("buddy.protocol.mcp.handlers.completion")
+require("buddy.protocol.mcp.handlers.notifications")
+
+-- Re-export content helpers
+local content = require("buddy.protocol.mcp.content")
+M.image_content = content.image_content
+M.audio_content = content.audio_content
+M.resource_content = content.resource_content
+M.embedded_resource = content.embedded_resource
+M.embedded_blob = content.embedded_blob
+M.resource_link = content.resource_link
+
+-- Re-export log level accessor from core handler
+local core = require("buddy.protocol.mcp.handlers.core")
+M.get_log_level = core.get_log_level
+
+-- Notification callback state — still owned here for backward compatibility
+-- (router.lua sets this via methods.set_notify_callback)
 M._notify_callback = nil
-
--- Module-level subscription tracking
-local subscriptions = {}
 
 function M.set_notify_callback(callback)
   M._notify_callback = callback
@@ -47,7 +70,6 @@ function M.notify_resource_updated(uri)
 end
 
 --- Set up buffer change watching for resource notifications
---- Call this when a buffer is subscribed to
 ---@param bufnr number Buffer number
 ---@param uri string Resource URI
 function M.watch_buffer(bufnr, uri)
@@ -74,396 +96,13 @@ function M.send_cancelled(request_id, reason)
   end
 end
 
-M["ping"] = function(_session_id, _params)
-  return vim.empty_dict()
-end
-
-M["initialize"] = function(session_id, params)
-  -- Store client capabilities for this session
-  local session_state = require("buddy.mcp.session_state")
-  session_state.initialize(session_id, params)
-
-  return {
-    protocolVersion = "2025-06-18",
-    capabilities = {
-      tools = { listChanged = true },
-      logging = vim.empty_dict(),
-      resources = { listChanged = true, subscribe = true },
-      prompts = { listChanged = true },
-      completion = vim.empty_dict(),
-    },
-    serverInfo = {
-      name = "buddy",
-      version = "2.0.0",
-      title = "Neovim Buddy",
-    },
-    instructions = "buddy provides tools for interacting with Neovim. Tools prefixed with 'vim_' operate on the connected Neovim instance. Use vim_status to check current state before making changes. Use vim_diagnostics to check for errors after edits.",
-  }
-end
-
-M["notifications/initialized"] = function(_session_id, _params)
-  return nil
-end
-
-M["notifications/cancelled"] = function(_session_id, params)
-  local log = require("buddy.log")
-  if params and params.requestId then
-    log.debug("Client cancelled request: %s", tostring(params.requestId))
-    -- Future: could cancel in-progress tool execution
-  end
-  return nil  -- notifications don't return
-end
-
-M["notifications/roots/list_changed"] = function(session_id, _params)
-  local log = require("buddy.log")
-  log.info("Client workspace roots changed")
-
-  -- Optionally refresh our cached roots
-  local session_state = require("buddy.mcp.session_state")
-  local state = session_state.get(session_id)
-  if state then
-    -- Clear cached roots so next roots.list() fetches fresh
-    state.cached_roots = nil
-  end
-
-  return nil  -- notifications don't return
-end
-
---- Handle progress notifications from client (for our server-to-client requests)
-M["notifications/progress"] = function(_session_id, params)
-  local log = require("buddy.log")
-  if params then
-    log.debug("Progress: %s/%s - %s",
-      tostring(params.progress),
-      tostring(params.total or "?"),
-      params.message or "")
-  end
-  return nil  -- notifications don't return
-end
-
--- Module-level state
-local log_level = "info"
-
-M["logging/setLevel"] = function(_session_id, params)
-  if params and params.level then
-    log_level = params.level
-    local log = require("buddy.log")
-    log.set_level(params.level)
-  end
-  return vim.empty_dict()
-end
-
--- Export for log.lua to check
-M.get_log_level = function()
-  return log_level
-end
-
-M["tools/list"] = function(_session_id, params)
-  local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
-  local tool_list = tools.list()
-
-  local mcp_tools = {}
-  for _, tool in ipairs(tool_list) do
-    local schema
-    if tool.input_schema then
-      schema = vim.deepcopy(tool.input_schema)
-      -- Ensure properties is object not array for JSON encoding
-      if schema.properties and next(schema.properties) == nil then
-        schema.properties = vim.empty_dict()
-      end
-    else
-      schema = { type = "object", properties = vim.empty_dict() }
-    end
-
-    local mcp_tool = {
-      name = tool.name,
-      description = tool.description or "",
-      inputSchema = schema,
-    }
-    -- Optional fields - only include if present
-    if tool.title then mcp_tool.title = tool.title end
-    if tool.annotations then mcp_tool.annotations = tool.annotations end
-    if tool.output_schema then mcp_tool.outputSchema = tool.output_schema end
-    table.insert(mcp_tools, mcp_tool)
-  end
-
-  return { tools = mcp_tools }  -- omit nextCursor when no more pages
-end
-
-M["tools/call"] = function(session_id, params, _request_id)
-  local errors = require("buddy.tools.errors")
-
-  if not params or not params.name then
-    error("Missing required parameter: name")
-  end
-
-  local tool_name = params.name
-  local tool = tools.get(tool_name)
-  if not tool then
-    error("Tool not found: " .. params.name)
-  end
-
-  local args = params.arguments or {}
-  local progress_token = params._meta and params._meta.progressToken
-
-  -- Execute tool with session context for server-to-client requests
-  local ok, result = pcall(executor.execute, tool_name, args, {
-    session_id = session_id,
-    progress_token = progress_token,
-    on_progress = progress_token and function(progress, total, message)
-      if M._notify_callback then
-        M._notify_callback({
-          method = "notifications/progress",
-          params = {
-            progressToken = progress_token,
-            progress = progress,
-            total = total,
-            message = message,
-          },
-        })
-      end
-    end or nil,
-  })
-
-  if not ok then
-    return errors.to_mcp_response(result)
-  end
-
-  local text_result
-  local structured_result
-  if type(result) == "table" then
-    text_result = vim.json.encode(result)
-    -- Include structuredContent if tool has outputSchema
-    if tool.output_schema then
-      structured_result = result
-    end
-  else
-    text_result = tostring(result)
-  end
-
-  local response = {
-    content = {
-      {
-        type = "text",
-        text = text_result
-      }
-    }
-  }
-  if structured_result then
-    response.structuredContent = structured_result
-  end
-  return response
-end
-
-M["resources/list"] = function(_session_id, params)
-  local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
-  local resources = require("buddy.resources")
-  return { resources = resources.list() }  -- omit nextCursor when no more pages
-end
-
-M["resources/templates/list"] = function(_session_id, params)
-  local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
-  local resources = require("buddy.resources")
-  return { resourceTemplates = resources.list_templates() }  -- omit nextCursor when no more pages
-end
-
-M["resources/read"] = function(_session_id, params)
-  if not params or not params.uri then
-    error("Missing required parameter: uri")
-  end
-  local resources = require("buddy.resources")
-  local content = resources.read(params.uri)
-  if not content then
-    error("Resource not found: " .. params.uri)
-  end
-  return { contents = content }
-end
-
-M["resources/subscribe"] = function(session_id, params)
-  if not params or not params.uri then
-    error("Missing required parameter: uri")
-  end
-
-  subscriptions[session_id] = subscriptions[session_id] or {}
-  subscriptions[session_id][params.uri] = true
-
-  return vim.empty_dict()
-end
-
-M["resources/unsubscribe"] = function(session_id, params)
-  if not params or not params.uri then
-    error("Missing required parameter: uri")
-  end
-
-  if subscriptions[session_id] then
-    subscriptions[session_id][params.uri] = nil
-  end
-
-  return vim.empty_dict()
-end
-
-M["prompts/list"] = function(_session_id, params)
-  local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
-  local prompts = require("buddy.prompts")
-  return { prompts = prompts.list() }  -- omit nextCursor when no more pages
-end
-
-M["prompts/get"] = function(_session_id, params)
-  if not params or not params.name then
-    error("Missing required parameter: name")
-  end
-  local prompts = require("buddy.prompts")
-  local result = prompts.get(params.name, params.arguments or {})
-  if not result then
-    error("Prompt not found: " .. params.name)
-  end
-  return result
-end
-
-M["completion/complete"] = function(_session_id, params)
-  if not params or not params.ref then
-    error("Missing required parameter: ref")
-  end
-
-  local ref = params.ref
-  local argument = params.argument or {}
-  local values = {}
-
-  -- Handle prompt argument completion
-  if ref.type == "ref/prompt" then
-    local prompt_name = ref.name
-    local arg_name = argument.name
-
-    -- Provide suggestions based on prompt and argument
-    if prompt_name == "refactor_selection" and arg_name == "goal" then
-      values = {
-        { value = "simplify", description = "Simplify complex code" },
-        { value = "extract", description = "Extract to function/variable" },
-        { value = "rename", description = "Improve naming" },
-        { value = "dry", description = "Remove duplication" },
-      }
-    elseif prompt_name == "write_tests" and arg_name == "framework" then
-      values = {
-        { value = "mini.test", description = "mini.nvim test framework" },
-        { value = "plenary", description = "Plenary test framework" },
-        { value = "busted", description = "Busted test framework" },
-      }
-    elseif prompt_name == "explain_buffer" and arg_name == "focus" then
-      values = {
-        { value = "overall structure", description = "High-level overview" },
-        { value = "error handling", description = "How errors are handled" },
-        { value = "performance", description = "Performance considerations" },
-        { value = "dependencies", description = "External dependencies" },
-      }
-    end
-    -- Handle resource URI completion
-  elseif ref.type == "ref/resource" then
-    -- Suggest buffer URIs
-    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-      if vim.api.nvim_buf_is_loaded(bufnr) then
-        local name = vim.api.nvim_buf_get_name(bufnr)
-        if name and name ~= "" then
-          table.insert(values, {
-            value = "vim://buffer/" .. bufnr,
-            description = vim.fn.fnamemodify(name, ":t"),
-          })
-        end
-      end
-    end
-  end
-
-  return {
-    completion = {
-      values = values,
-      total = #values,
-      hasMore = false,
-    },
-  }
-end
-
--- Export helper for creating image content
-M.image_content = function(base64_data, mime_type)
-  return {
-    type = "image",
-    data = base64_data,
-    mimeType = mime_type or "image/png",
-  }
-end
-
---- Create an AudioContent block
----@param base64_data string Base64-encoded audio data
----@param mime_type string MIME type (e.g., "audio/wav", "audio/mp3", "audio/ogg")
----@return table
-function M.audio_content(base64_data, mime_type)
-  return {
-    type = "audio",
-    data = base64_data,
-    mimeType = mime_type,
-  }
-end
-
-M.resource_content = function(uri, mime_type, text)
-  return {
-    type = "resource",
-    resource = {
-      uri = uri,
-      mimeType = mime_type or "text/plain",
-      text = text,
-    },
-  }
-end
-
---- Create an EmbeddedResource content block
---- Use when returning actual resource content in a tool response
----@param uri string Resource URI
----@param text string Text content
----@param mime_type? string MIME type (default: text/plain)
----@return table
-function M.embedded_resource(uri, text, mime_type)
-  return {
-    type = "resource",
-    resource = {
-      uri = uri,
-      mimeType = mime_type or "text/plain",
-      text = text,
-    },
-  }
-end
-
---- Create an EmbeddedResource with binary blob
----@param uri string Resource URI
----@param blob string Base64-encoded binary data
----@param mime_type string MIME type
----@return table
-function M.embedded_blob(uri, blob, mime_type)
-  return {
-    type = "resource",
-    resource = {
-      uri = uri,
-      mimeType = mime_type,
-      blob = blob,
-    },
-  }
-end
-
---- Create a ResourceLink content block (reference without content)
----@param uri string Resource URI
----@param name string Human-readable name (required)
----@param description? string Description
----@param mime_type? string MIME type
----@return table
-function M.resource_link(uri, name, description, mime_type)
-  if not name or name == "" then
-    error("ResourceLink requires a name")
-  end
-  local link = {
-    type = "resource_link",
-    uri = uri,
-    name = name,
-  }
-  if description then link.description = description end
-  if mime_type then link.mimeType = mime_type end
-  return link
-end
+-- Proxy handler lookups through the registry for backward compatibility
+-- Supports: methods["tools/list"], methods["initialize"], etc.
+local registry = require("buddy.protocol.mcp.registry")
+setmetatable(M, {
+  __index = function(_self, key)
+    return registry.get(key)
+  end,
+})
 
 return M

--- a/lua/buddy/protocol/jsonrpc.lua
+++ b/lua/buddy/protocol/jsonrpc.lua
@@ -1,0 +1,61 @@
+--- JSON-RPC 2.0 request validation and response frame builders
+local M = {}
+
+--- Validate a JSON-RPC 2.0 request envelope
+---@param req table The request table to validate
+---@return boolean valid
+---@return string|nil error_message
+function M.validate_request(req)
+  if type(req) ~= "table" then
+    return false, "Request must be a JSON object"
+  end
+
+  if req.jsonrpc ~= "2.0" then
+    return false, "Missing or invalid jsonrpc version (must be '2.0')"
+  end
+
+  if not req.method then
+    return false, "Missing 'method' field"
+  end
+
+  return true, nil
+end
+
+--- Build a JSON-RPC 2.0 success response
+---@param id any The request id
+---@param result any The result payload
+---@return table
+function M.result(id, result)
+  return {
+    jsonrpc = "2.0",
+    id = id,
+    result = result,
+  }
+end
+
+--- Build a JSON-RPC 2.0 error response
+--- Standard codes: -32700 Parse, -32600 Invalid Request, -32601 Method not found,
+--- -32602 Invalid params, -32603 Internal
+---@param id any The request id
+---@param code number The error code
+---@param message string The error message
+---@param data any|nil Optional error data
+---@return table
+function M.error(id, code, message, data)
+  local response = {
+    jsonrpc = "2.0",
+    id = id,
+    error = {
+      code = code,
+      message = message,
+    },
+  }
+
+  if data ~= nil then
+    response.error.data = data
+  end
+
+  return response
+end
+
+return M

--- a/lua/buddy/protocol/mcp/content.lua
+++ b/lua/buddy/protocol/mcp/content.lua
@@ -1,0 +1,98 @@
+--- MCP content type constructors
+--- Helpers for building image, audio, resource, and link content blocks
+local M = {}
+
+--- Create an ImageContent block
+---@param base64_data string Base64-encoded image data
+---@param mime_type? string MIME type (default: image/png)
+---@return table
+function M.image_content(base64_data, mime_type)
+  return {
+    type = "image",
+    data = base64_data,
+    mimeType = mime_type or "image/png",
+  }
+end
+
+--- Create an AudioContent block
+---@param base64_data string Base64-encoded audio data
+---@param mime_type string MIME type (e.g., "audio/wav", "audio/mp3", "audio/ogg")
+---@return table
+function M.audio_content(base64_data, mime_type)
+  return {
+    type = "audio",
+    data = base64_data,
+    mimeType = mime_type,
+  }
+end
+
+--- Create a ResourceContent block (text-based)
+---@param uri string Resource URI
+---@param mime_type? string MIME type (default: text/plain)
+---@param text string Text content
+---@return table
+function M.resource_content(uri, mime_type, text)
+  return {
+    type = "resource",
+    resource = {
+      uri = uri,
+      mimeType = mime_type or "text/plain",
+      text = text,
+    },
+  }
+end
+
+--- Create an EmbeddedResource content block
+--- Use when returning actual resource content in a tool response
+---@param uri string Resource URI
+---@param text string Text content
+---@param mime_type? string MIME type (default: text/plain)
+---@return table
+function M.embedded_resource(uri, text, mime_type)
+  return {
+    type = "resource",
+    resource = {
+      uri = uri,
+      mimeType = mime_type or "text/plain",
+      text = text,
+    },
+  }
+end
+
+--- Create an EmbeddedResource with binary blob
+---@param uri string Resource URI
+---@param blob string Base64-encoded binary data
+---@param mime_type string MIME type
+---@return table
+function M.embedded_blob(uri, blob, mime_type)
+  return {
+    type = "resource",
+    resource = {
+      uri = uri,
+      mimeType = mime_type,
+      blob = blob,
+    },
+  }
+end
+
+--- Create a ResourceLink content block (reference without content)
+---@param uri string Resource URI
+---@param name string Human-readable name (required)
+---@param description? string Description
+---@param mime_type? string MIME type
+---@return table
+function M.resource_link(uri, name, description, mime_type)
+  if not name or name == "" then
+    error("ResourceLink requires a name")
+  end
+  local link = {
+    type = "resource_link",
+    uri = uri,
+    name = name,
+  }
+  if description then link.description = description end
+  if mime_type then link.mimeType = mime_type end
+  return link
+end
+
+return M

--- a/lua/buddy/protocol/mcp/dispatcher.lua
+++ b/lua/buddy/protocol/mcp/dispatcher.lua
@@ -1,0 +1,64 @@
+--- MCP protocol dispatcher
+--- Validates JSON-RPC envelope, looks up handler in registry, calls it
+local jsonrpc = require("buddy.protocol.jsonrpc")
+local registry = require("buddy.protocol.mcp.registry")
+
+local M = {}
+
+-- Ensure all handler modules are loaded (registers handlers in registry)
+local _loaded = false
+local function _ensure_handlers()
+  if _loaded then return end
+  require("buddy.protocol.mcp.handlers.core")
+  require("buddy.protocol.mcp.handlers.tools")
+  require("buddy.protocol.mcp.handlers.resources")
+  require("buddy.protocol.mcp.handlers.prompts")
+  require("buddy.protocol.mcp.handlers.completion")
+  require("buddy.protocol.mcp.handlers.notifications")
+  _loaded = true
+end
+
+--- Handle an incoming MCP request
+--- Validates JSON-RPC, resolves handler, and returns the response envelope
+---@param session_id string The SSE session ID
+---@param request table The parsed JSON-RPC request
+---@return table|nil response JSON-RPC response, or nil for notifications
+function M.handle_request(session_id, request)
+  _ensure_handlers()
+
+  local valid, err = jsonrpc.validate_request(request)
+  if not valid then
+    if request.id then
+      return jsonrpc.error(request.id, -32600, "Invalid Request", err)
+    end
+    return nil
+  end
+
+  local is_notification = request.id == nil
+
+  local handler = registry.get(request.method)
+
+  if not handler then
+    if is_notification then
+      return nil
+    end
+    return jsonrpc.error(request.id, -32601, "Method not found", "Unknown method: " .. request.method)
+  end
+
+  local ok, result = pcall(handler, session_id, request.params or {}, request.id)
+
+  if not ok then
+    if is_notification then
+      return nil
+    end
+    return jsonrpc.error(request.id, -32603, "Internal error", tostring(result))
+  end
+
+  if is_notification then
+    return nil
+  end
+
+  return jsonrpc.result(request.id, result)
+end
+
+return M

--- a/lua/buddy/protocol/mcp/errors.lua
+++ b/lua/buddy/protocol/mcp/errors.lua
@@ -1,0 +1,94 @@
+--- MCP and JSON-RPC protocol error code constants and mapping helpers
+---
+--- Centralizes error codes defined by JSON-RPC 2.0 and the MCP specification.
+--- Provides helpers for constructing well-formed error response objects.
+
+local M = {}
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- JSON-RPC 2.0 standard error codes
+-- ────────────────────────────────────────────────────────────────────────────
+
+---@enum JsonRpcErrorCode
+M.PARSE_ERROR = -32700
+M.INVALID_REQUEST = -32600
+M.METHOD_NOT_FOUND = -32601
+M.INVALID_PARAMS = -32602
+M.INTERNAL_ERROR = -32603
+
+-- JSON-RPC reserved server error range: -32000 to -32099
+-- MCP uses this range for protocol-specific errors.
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- MCP-specific error codes (within JSON-RPC server error range)
+-- ────────────────────────────────────────────────────────────────────────────
+
+M.REQUEST_CANCELLED = -32800
+M.CONTENT_TOO_LARGE = -32801
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Human-readable messages for each code
+-- ────────────────────────────────────────────────────────────────────────────
+
+---@type table<number, string>
+M.messages = {
+  [M.PARSE_ERROR] = "Parse error",
+  [M.INVALID_REQUEST] = "Invalid Request",
+  [M.METHOD_NOT_FOUND] = "Method not found",
+  [M.INVALID_PARAMS] = "Invalid params",
+  [M.INTERNAL_ERROR] = "Internal error",
+  [M.REQUEST_CANCELLED] = "Request cancelled",
+  [M.CONTENT_TOO_LARGE] = "Content too large",
+}
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Helpers
+-- ────────────────────────────────────────────────────────────────────────────
+
+--- Get the default message for an error code
+---@param code number JSON-RPC/MCP error code
+---@return string message
+function M.message_for(code)
+  return M.messages[code] or "Unknown error"
+end
+
+--- Build a JSON-RPC error response object
+---
+---@param id any Request id (number, string, or vim.NIL)
+---@param code number Error code
+---@param message string|nil Human-readable message (defaults to code's standard message)
+---@param data any|nil Additional error data
+---@return table response JSON-RPC error response: { jsonrpc, id, error = { code, message, data? } }
+function M.response(id, code, message, data)
+  local err_obj = {
+    code = code,
+    message = message or M.message_for(code),
+  }
+  if data ~= nil then
+    err_obj.data = data
+  end
+  return {
+    jsonrpc = "2.0",
+    id = id,
+    error = err_obj,
+  }
+end
+
+--- Build just the error object (without the full response envelope)
+---
+---@param code number Error code
+---@param message string|nil Human-readable message
+---@param data any|nil Additional error data
+---@return table error_object { code, message, data? }
+function M.object(code, message, data)
+  local err_obj = {
+    code = code,
+    message = message or M.message_for(code),
+  }
+  if data ~= nil then
+    err_obj.data = data
+  end
+  return err_obj
+end
+
+return M

--- a/lua/buddy/protocol/mcp/handlers/completion.lua
+++ b/lua/buddy/protocol/mcp/handlers/completion.lua
@@ -1,0 +1,63 @@
+--- MCP completion handler: completion/complete
+local registry = require("buddy.protocol.mcp.registry")
+
+registry.register("completion/complete", function(_session_id, params)
+  if not params or not params.ref then
+    error("Missing required parameter: ref")
+  end
+
+  local ref = params.ref
+  local argument = params.argument or {}
+  local values = {}
+
+  -- Handle prompt argument completion
+  if ref.type == "ref/prompt" then
+    local prompt_name = ref.name
+    local arg_name = argument.name
+
+    -- Provide suggestions based on prompt and argument
+    if prompt_name == "refactor_selection" and arg_name == "goal" then
+      values = {
+        { value = "simplify", description = "Simplify complex code" },
+        { value = "extract", description = "Extract to function/variable" },
+        { value = "rename", description = "Improve naming" },
+        { value = "dry", description = "Remove duplication" },
+      }
+    elseif prompt_name == "write_tests" and arg_name == "framework" then
+      values = {
+        { value = "mini.test", description = "mini.nvim test framework" },
+        { value = "plenary", description = "Plenary test framework" },
+        { value = "busted", description = "Busted test framework" },
+      }
+    elseif prompt_name == "explain_buffer" and arg_name == "focus" then
+      values = {
+        { value = "overall structure", description = "High-level overview" },
+        { value = "error handling", description = "How errors are handled" },
+        { value = "performance", description = "Performance considerations" },
+        { value = "dependencies", description = "External dependencies" },
+      }
+    end
+    -- Handle resource URI completion
+  elseif ref.type == "ref/resource" then
+    -- Suggest buffer URIs
+    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_loaded(bufnr) then
+        local name = vim.api.nvim_buf_get_name(bufnr)
+        if name and name ~= "" then
+          table.insert(values, {
+            value = "vim://buffer/" .. bufnr,
+            description = vim.fn.fnamemodify(name, ":t"),
+          })
+        end
+      end
+    end
+  end
+
+  return {
+    completion = {
+      values = values,
+      total = #values,
+      hasMore = false,
+    },
+  }
+end)

--- a/lua/buddy/protocol/mcp/handlers/core.lua
+++ b/lua/buddy/protocol/mcp/handlers/core.lua
@@ -1,0 +1,50 @@
+--- MCP core handlers: initialize, ping, logging/setLevel
+local registry = require("buddy.protocol.mcp.registry")
+
+local M = {}
+
+-- Module-level state
+local log_level = "info"
+
+--- Export for log.lua to check
+function M.get_log_level()
+  return log_level
+end
+
+registry.register("ping", function(_session_id, _params)
+  return vim.empty_dict()
+end)
+
+registry.register("initialize", function(session_id, params)
+  -- Store client capabilities for this session
+  local session_state = require("buddy.mcp.session_state")
+  session_state.initialize(session_id, params)
+
+  return {
+    protocolVersion = "2025-06-18",
+    capabilities = {
+      tools = { listChanged = true },
+      logging = vim.empty_dict(),
+      resources = { listChanged = true, subscribe = true },
+      prompts = { listChanged = true },
+      completion = vim.empty_dict(),
+    },
+    serverInfo = {
+      name = "buddy",
+      version = "2.0.0",
+      title = "Neovim Buddy",
+    },
+    instructions = "buddy provides tools for interacting with Neovim. Tools prefixed with 'vim_' operate on the connected Neovim instance. Use vim_status to check current state before making changes. Use vim_diagnostics to check for errors after edits.",
+  }
+end)
+
+registry.register("logging/setLevel", function(_session_id, params)
+  if params and params.level then
+    log_level = params.level
+    local log = require("buddy.log")
+    log.set_level(params.level)
+  end
+  return vim.empty_dict()
+end)
+
+return M

--- a/lua/buddy/protocol/mcp/handlers/notifications.lua
+++ b/lua/buddy/protocol/mcp/handlers/notifications.lua
@@ -1,0 +1,43 @@
+--- MCP notification handlers: notifications/cancelled, notifications/initialized,
+--- notifications/roots/list_changed, notifications/progress
+local registry = require("buddy.protocol.mcp.registry")
+
+registry.register("notifications/initialized", function(_session_id, _params)
+  return nil
+end)
+
+registry.register("notifications/cancelled", function(_session_id, params)
+  local log = require("buddy.log")
+  if params and params.requestId then
+    log.debug("Client cancelled request: %s", tostring(params.requestId))
+    -- Future: could cancel in-progress tool execution
+  end
+  return nil  -- notifications don't return
+end)
+
+registry.register("notifications/roots/list_changed", function(session_id, _params)
+  local log = require("buddy.log")
+  log.info("Client workspace roots changed")
+
+  -- Optionally refresh our cached roots
+  local session_state = require("buddy.mcp.session_state")
+  local state = session_state.get(session_id)
+  if state then
+    -- Clear cached roots so next roots.list() fetches fresh
+    state.cached_roots = nil
+  end
+
+  return nil  -- notifications don't return
+end)
+
+--- Handle progress notifications from client (for our server-to-client requests)
+registry.register("notifications/progress", function(_session_id, params)
+  local log = require("buddy.log")
+  if params then
+    log.debug("Progress: %s/%s - %s",
+      tostring(params.progress),
+      tostring(params.total or "?"),
+      params.message or "")
+  end
+  return nil  -- notifications don't return
+end)

--- a/lua/buddy/protocol/mcp/handlers/prompts.lua
+++ b/lua/buddy/protocol/mcp/handlers/prompts.lua
@@ -1,0 +1,20 @@
+--- MCP prompts handlers: prompts/list, prompts/get
+local registry = require("buddy.protocol.mcp.registry")
+
+registry.register("prompts/list", function(_session_id, params)
+  local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
+  local prompts = require("buddy.prompts")
+  return { prompts = prompts.list() }  -- omit nextCursor when no more pages
+end)
+
+registry.register("prompts/get", function(_session_id, params)
+  if not params or not params.name then
+    error("Missing required parameter: name")
+  end
+  local prompts = require("buddy.prompts")
+  local result = prompts.get(params.name, params.arguments or {})
+  if not result then
+    error("Prompt not found: " .. params.name)
+  end
+  return result
+end)

--- a/lua/buddy/protocol/mcp/handlers/resources.lua
+++ b/lua/buddy/protocol/mcp/handlers/resources.lua
@@ -1,0 +1,53 @@
+--- MCP resources handlers: resources/list, resources/templates/list,
+--- resources/read, resources/subscribe, resources/unsubscribe
+local registry = require("buddy.protocol.mcp.registry")
+
+-- Module-level subscription tracking
+local subscriptions = {}
+
+registry.register("resources/list", function(_session_id, params)
+  local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
+  local resources = require("buddy.resources")
+  return { resources = resources.list() }  -- omit nextCursor when no more pages
+end)
+
+registry.register("resources/templates/list", function(_session_id, params)
+  local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
+  local resources = require("buddy.resources")
+  return { resourceTemplates = resources.list_templates() }  -- omit nextCursor when no more pages
+end)
+
+registry.register("resources/read", function(_session_id, params)
+  if not params or not params.uri then
+    error("Missing required parameter: uri")
+  end
+  local resources = require("buddy.resources")
+  local content = resources.read(params.uri)
+  if not content then
+    error("Resource not found: " .. params.uri)
+  end
+  return { contents = content }
+end)
+
+registry.register("resources/subscribe", function(session_id, params)
+  if not params or not params.uri then
+    error("Missing required parameter: uri")
+  end
+
+  subscriptions[session_id] = subscriptions[session_id] or {}
+  subscriptions[session_id][params.uri] = true
+
+  return vim.empty_dict()
+end)
+
+registry.register("resources/unsubscribe", function(session_id, params)
+  if not params or not params.uri then
+    error("Missing required parameter: uri")
+  end
+
+  if subscriptions[session_id] then
+    subscriptions[session_id][params.uri] = nil
+  end
+
+  return vim.empty_dict()
+end)

--- a/lua/buddy/protocol/mcp/handlers/tools.lua
+++ b/lua/buddy/protocol/mcp/handlers/tools.lua
@@ -1,0 +1,102 @@
+--- MCP tools handlers: tools/list, tools/call
+local registry = require("buddy.protocol.mcp.registry")
+local tools = require("buddy.tools")
+local executor = require("buddy.tools.executor")
+
+registry.register("tools/list", function(_session_id, params)
+  local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
+  local tool_list = tools.list()
+
+  local mcp_tools = {}
+  for _, tool in ipairs(tool_list) do
+    local schema
+    if tool.input_schema then
+      schema = vim.deepcopy(tool.input_schema)
+      -- Ensure properties is object not array for JSON encoding
+      if schema.properties and next(schema.properties) == nil then
+        schema.properties = vim.empty_dict()
+      end
+    else
+      schema = { type = "object", properties = vim.empty_dict() }
+    end
+
+    local mcp_tool = {
+      name = tool.name,
+      description = tool.description or "",
+      inputSchema = schema,
+    }
+    -- Optional fields - only include if present
+    if tool.title then mcp_tool.title = tool.title end
+    if tool.annotations then mcp_tool.annotations = tool.annotations end
+    if tool.output_schema then mcp_tool.outputSchema = tool.output_schema end
+    table.insert(mcp_tools, mcp_tool)
+  end
+
+  return { tools = mcp_tools }  -- omit nextCursor when no more pages
+end)
+
+registry.register("tools/call", function(session_id, params, _request_id)
+  local errors = require("buddy.tools.errors")
+  local methods = require("buddy.mcp.methods")
+
+  if not params or not params.name then
+    error("Missing required parameter: name")
+  end
+
+  local tool_name = params.name
+  local tool = tools.get(tool_name)
+  if not tool then
+    error("Tool not found: " .. params.name)
+  end
+
+  local args = params.arguments or {}
+  local progress_token = params._meta and params._meta.progressToken
+
+  -- Execute tool with session context for server-to-client requests
+  local ok, result = pcall(executor.execute, tool_name, args, {
+    session_id = session_id,
+    progress_token = progress_token,
+    on_progress = progress_token and function(progress, total, message)
+      if methods._notify_callback then
+        methods._notify_callback({
+          method = "notifications/progress",
+          params = {
+            progressToken = progress_token,
+            progress = progress,
+            total = total,
+            message = message,
+          },
+        })
+      end
+    end or nil,
+  })
+
+  if not ok then
+    return errors.to_mcp_response(result)
+  end
+
+  local text_result
+  local structured_result
+  if type(result) == "table" then
+    text_result = vim.json.encode(result)
+    -- Include structuredContent if tool has outputSchema
+    if tool.output_schema then
+      structured_result = result
+    end
+  else
+    text_result = tostring(result)
+  end
+
+  local response = {
+    content = {
+      {
+        type = "text",
+        text = text_result,
+      },
+    },
+  }
+  if structured_result then
+    response.structuredContent = structured_result
+  end
+  return response
+end)

--- a/lua/buddy/protocol/mcp/registry.lua
+++ b/lua/buddy/protocol/mcp/registry.lua
@@ -1,0 +1,28 @@
+--- MCP method handler registry
+--- Central registration table for protocol method handlers
+local M = {}
+
+---@type table<string, function>
+local _handlers = {}
+
+--- Register a method handler
+---@param method string The MCP method name (e.g., "tools/list")
+---@param handler function Handler function(session_id, params, request_id?) -> result|nil
+function M.register(method, handler)
+  _handlers[method] = handler
+end
+
+--- Get a handler for a method
+---@param method string The MCP method name
+---@return function|nil handler
+function M.get(method)
+  return _handlers[method]
+end
+
+--- Get all registered handlers
+---@return table<string, function>
+function M.all()
+  return _handlers
+end
+
+return M

--- a/lua/buddy/runtime/event_bus.lua
+++ b/lua/buddy/runtime/event_bus.lua
@@ -1,0 +1,79 @@
+--- Internal pub/sub event bus for buddy.nvim runtime
+---
+--- Provides decoupled communication between subsystems (transport, protocol,
+--- services) without direct module dependencies. Subscribers receive events
+--- asynchronously via vim.schedule to avoid reentrancy issues.
+
+---@class BuddyEventBus
+---@field _listeners table<string, table[]> event -> list of {cb, active}
+local EventBus = {}
+EventBus.__index = EventBus
+
+--- Create a new EventBus instance
+---@return BuddyEventBus
+function EventBus.new()
+  local self = setmetatable({}, EventBus)
+  self._listeners = {}
+  return self
+end
+
+--- Subscribe to an event
+---
+--- The callback receives the event payload table (or nil). Returns an
+--- unsubscribe function that, when called, removes this specific listener.
+---
+---@param event string Event name (e.g. "session_connected")
+---@param cb function Callback: fun(payload: table|nil)
+---@return fun() unsubscribe Call to remove this listener
+function EventBus:subscribe(event, cb)
+  if not self._listeners[event] then
+    self._listeners[event] = {}
+  end
+
+  local entry = { cb = cb, active = true }
+  table.insert(self._listeners[event], entry)
+
+  return function()
+    entry.active = false
+  end
+end
+
+--- Publish an event to all active subscribers
+---
+--- Inactive (unsubscribed) entries are pruned during iteration. Callbacks
+--- are invoked synchronously in subscription order. Errors in individual
+--- callbacks are caught with pcall and logged, but do not prevent other
+--- subscribers from receiving the event.
+---
+---@param event string Event name
+---@param payload table|nil Event data
+function EventBus:publish(event, payload)
+  local listeners = self._listeners[event]
+  if not listeners then
+    return
+  end
+
+  -- Iterate and prune dead entries in one pass
+  local write = 0
+  for i = 1, #listeners do
+    local entry = listeners[i]
+    if entry.active then
+      write = write + 1
+      listeners[write] = entry
+      local ok, err = pcall(entry.cb, payload)
+      if not ok then
+        local log_ok, log = pcall(require, "buddy.log")
+        if log_ok and log.error then
+          log.error("EventBus: error in '%s' handler: %s", event, tostring(err))
+        end
+      end
+    end
+  end
+
+  -- Trim removed entries
+  for i = write + 1, #listeners do
+    listeners[i] = nil
+  end
+end
+
+return EventBus

--- a/lua/buddy/runtime/state/request_store.lua
+++ b/lua/buddy/runtime/state/request_store.lua
@@ -1,0 +1,108 @@
+--- Inflight request tracking for buddy.nvim runtime
+---
+--- Tracks in-progress requests (both client→server and server→client) with
+--- session association for bulk cleanup on disconnect.
+
+---@class RequestEntry
+---@field key string Request identifier
+---@field session_id string|nil Associated session
+---@field status "pending"|"resolved"|"rejected" Current state
+---@field meta table Caller-provided metadata (method, params, timestamps, etc.)
+---@field result any|nil Resolution value (set on resolve)
+---@field error any|nil Rejection reason (set on reject)
+---@field started_at number Timestamp (vim.uv.hrtime)
+
+---@class RequestStore
+---@field _requests table<string, RequestEntry>
+local RequestStore = {}
+RequestStore.__index = RequestStore
+
+--- Create a new RequestStore instance
+---@return RequestStore
+function RequestStore.new()
+  local self = setmetatable({}, RequestStore)
+  self._requests = {}
+  return self
+end
+
+--- Start tracking a new inflight request
+---
+--- meta should include session_id for cleanup_by_session to work:
+---   { session_id = "...", method = "...", ... }
+---
+---@param key string Unique request identifier
+---@param meta table Request metadata (must include session_id for session cleanup)
+function RequestStore:start(key, meta)
+  self._requests[key] = {
+    key = key,
+    session_id = meta.session_id,
+    status = "pending",
+    meta = meta,
+    result = nil,
+    error = nil,
+    started_at = vim.uv.hrtime(),
+  }
+end
+
+--- Resolve a pending request with a result
+---
+---@param key string Request identifier
+---@param result any Resolution value
+---@return boolean success True if request was pending and is now resolved
+function RequestStore:resolve(key, result)
+  local entry = self._requests[key]
+  if not entry or entry.status ~= "pending" then
+    return false
+  end
+  entry.status = "resolved"
+  entry.result = result
+  return true
+end
+
+--- Reject a pending request with an error
+---
+---@param key string Request identifier
+---@param err any Rejection reason
+---@return boolean success True if request was pending and is now rejected
+function RequestStore:reject(key, err)
+  local entry = self._requests[key]
+  if not entry or entry.status ~= "pending" then
+    return false
+  end
+  entry.status = "rejected"
+  entry.error = err
+  return true
+end
+
+--- Get a request entry by key
+---
+---@param key string Request identifier
+---@return RequestEntry|nil
+function RequestStore:get(key)
+  return self._requests[key]
+end
+
+--- Clean up all requests associated with a session
+---
+--- Removes all entries (pending, resolved, or rejected) whose meta.session_id
+--- matches the given session_id. Pending requests are rejected before removal.
+---
+---@param session_id string Session identifier
+function RequestStore:cleanup_by_session(session_id)
+  local to_remove = {}
+  for key, entry in pairs(self._requests) do
+    if entry.session_id == session_id then
+      -- Reject pending requests before removal
+      if entry.status == "pending" then
+        entry.status = "rejected"
+        entry.error = "session_closed"
+      end
+      to_remove[#to_remove + 1] = key
+    end
+  end
+  for _, key in ipairs(to_remove) do
+    self._requests[key] = nil
+  end
+end
+
+return RequestStore

--- a/lua/buddy/runtime/state/session_store.lua
+++ b/lua/buddy/runtime/state/session_store.lua
@@ -1,0 +1,113 @@
+--- Per-session state store for buddy.nvim runtime
+---
+--- Manages session lifecycle data: client capabilities, client info,
+--- resource subscriptions, and cached roots. This will eventually replace
+--- the module-level singleton in mcp/session_state.lua.
+
+---@class SessionEntry
+---@field session_id string
+---@field capabilities table Client capabilities from initialize
+---@field client_info table Client info from initialize
+---@field subscriptions table<string, boolean> URI -> true set
+---@field cached_roots table|nil Cached workspace roots
+---@field created_at number Timestamp (vim.uv.hrtime)
+
+---@class SessionStore
+---@field _sessions table<string, SessionEntry>
+local SessionStore = {}
+SessionStore.__index = SessionStore
+
+--- Create a new SessionStore instance
+---@return SessionStore
+function SessionStore.new()
+  local self = setmetatable({}, SessionStore)
+  self._sessions = {}
+  return self
+end
+
+--- Initialize a new session with params from the MCP initialize request
+---
+---@param session_id string Unique session identifier
+---@param init_params table Initialize params from client (capabilities, clientInfo, etc.)
+function SessionStore:init_session(session_id, init_params)
+  self._sessions[session_id] = {
+    session_id = session_id,
+    capabilities = init_params.capabilities or {},
+    client_info = init_params.clientInfo or {},
+    subscriptions = {},
+    cached_roots = nil,
+    created_at = vim.uv.hrtime(),
+  }
+end
+
+--- Get session state
+---
+---@param session_id string
+---@return SessionEntry|nil
+function SessionStore:get(session_id)
+  return self._sessions[session_id]
+end
+
+--- Update session with a shallow patch
+---
+--- Merges top-level keys from patch into the session entry.
+--- Does nothing if session does not exist.
+---
+---@param session_id string
+---@param patch table Key-value pairs to merge into session
+function SessionStore:update(session_id, patch)
+  local session = self._sessions[session_id]
+  if not session then
+    return
+  end
+  for k, v in pairs(patch) do
+    session[k] = v
+  end
+end
+
+--- Clean up a session, removing all associated state
+---
+---@param session_id string
+function SessionStore:cleanup(session_id)
+  self._sessions[session_id] = nil
+end
+
+--- Add a resource subscription for a session
+---
+---@param session_id string
+---@param uri string Resource URI to subscribe to
+function SessionStore:add_subscription(session_id, uri)
+  local session = self._sessions[session_id]
+  if not session then
+    return
+  end
+  session.subscriptions[uri] = true
+end
+
+--- Remove a resource subscription for a session
+---
+---@param session_id string
+---@param uri string Resource URI to unsubscribe from
+function SessionStore:remove_subscription(session_id, uri)
+  local session = self._sessions[session_id]
+  if not session then
+    return
+  end
+  session.subscriptions[uri] = nil
+end
+
+--- Find all session IDs subscribed to a given URI
+---
+---@param uri string Resource URI
+---@return string[] session_ids List of session IDs with active subscriptions
+function SessionStore:subscribers_for_uri(uri)
+  local result = {}
+  for session_id, session in pairs(self._sessions) do
+    if session.subscriptions[uri] then
+      result[#result + 1] = session_id
+    end
+  end
+  return result
+end
+
+return SessionStore

--- a/lua/buddy/server/http.lua
+++ b/lua/buddy/server/http.lua
@@ -253,6 +253,7 @@ function HTTPServer:send_response(client, status, headers, body)
     [200] = "OK",
     [202] = "Accepted",
     [400] = "Bad Request",
+    [401] = "Unauthorized",
     [404] = "Not Found",
     [500] = "Internal Server Error",
   })[status] or "OK"

--- a/lua/buddy/server/http.lua
+++ b/lua/buddy/server/http.lua
@@ -72,7 +72,9 @@ function HTTPServer:start(router)
   if ok then
     self.port = preferred_port
     self.running = true
-    print(string.format("HTTP server listening on http://%s:%d", host, preferred_port))
+    vim.schedule(function()
+      vim.notify(string.format("[buddy] HTTP server listening on http://%s:%d", host, preferred_port), vim.log.levels.INFO)
+    end)
     return preferred_port
   end
 
@@ -105,7 +107,6 @@ function HTTPServer:start(router)
           vim.log.levels.INFO
         )
       end)
-      print(string.format("HTTP server listening on http://%s:%d", host, try_port))
       return try_port
     end
   end
@@ -149,15 +150,31 @@ function HTTPServer:_handle_connection(client)
     version = "1.1",
   }
 
+  local function remove_connection()
+    for i, c in ipairs(self.connections) do
+      if c == client then
+        table.remove(self.connections, i)
+        break
+      end
+    end
+  end
+
   -- Read data from client
   client:read_start(vim.schedule_wrap(function(err, chunk)
     if err then
-      client:close()
+      remove_connection()
+      if not client:is_closing() then
+        client:close()
+      end
       return
     end
 
     if not chunk then
-      -- Connection closed
+      -- Connection closed - remove from tracking and close handle
+      remove_connection()
+      if not client:is_closing() then
+        client:close()
+      end
       return
     end
 
@@ -299,7 +316,7 @@ function HTTPServer:stop()
     self.server:close()
   end
 
-  print("HTTP server stopped")
+  vim.notify("[buddy] HTTP server stopped", vim.log.levels.INFO)
 end
 
 return HTTPServer

--- a/lua/buddy/server/router.lua
+++ b/lua/buddy/server/router.lua
@@ -5,6 +5,21 @@ local uv = vim.uv
 
 local M = {}
 
+-- Auth token for Bearer authentication (nil = auth disabled)
+local _auth_token = nil
+
+--- Set the auth token for request validation
+---@param token string|nil The Bearer token (nil disables auth)
+function M.set_auth_token(token)
+  _auth_token = token
+end
+
+--- Get the current auth token (for testing)
+---@return string|nil
+function M.get_auth_token()
+  return _auth_token
+end
+
 local function parse_query_params(path)
   local query_start = path:find("?")
   if not query_start then
@@ -33,6 +48,21 @@ function M.handle(http_server, client, request, body)
   local params, path = parse_query_params(request.path or "")
   request.params = params
   request.path = path
+
+  -- Auth check: skip for /health, enforce for all other endpoints
+  if _auth_token and path ~= "/health" then
+    local auth_header = request.headers["authorization"] or ""
+    local provided_token = auth_header:match("^Bearer%s+(.+)$")
+    if provided_token ~= _auth_token then
+      http_server:send_response(client, 401, {["Content-Type"] = "application/json"}, vim.json.encode({
+        error = {
+          code = -32001,
+          message = "Unauthorized: invalid or missing Bearer token",
+        },
+      }))
+      return
+    end
+  end
 
   if request.method == "GET" and path == "/sse" then
     M._handle_sse(http_server, client, request)

--- a/lua/buddy/server/router.lua
+++ b/lua/buddy/server/router.lua
@@ -8,6 +8,9 @@ local M = {}
 -- Auth token for Bearer authentication (nil = auth disabled)
 local _auth_token = nil
 
+-- Whether the notifier has been wired to methods (once per server lifetime)
+local _notifier_wired = false
+
 --- Set the auth token for request validation
 ---@param token string|nil The Bearer token (nil disables auth)
 function M.set_auth_token(token)
@@ -82,37 +85,33 @@ function M._handle_sse(http_server, client, _request)
 
   http_server.sse_connections[session_id] = sse_conn
 
-  -- Wire up notify callback to broadcast to all sessions
-  local methods = require("buddy.mcp.methods")
-  methods.set_notify_callback(function(notification)
-    local message = {
-      jsonrpc = "2.0",
-      method = notification.method,
-    }
-    if notification.params then
-      message.params = notification.params
-    end
+  -- Wire notifier once (not per session) to route notifications through Notifier service
+  if not _notifier_wired then
+    local SSEHub = require("buddy.transport.sse.hub")
+    local Notifier = require("buddy.services.notifier")
+    local hub = SSEHub.get_instance(http_server)
 
-    -- Broadcast to all active SSE connections
-    local dead_sessions = {}
-    for sid, conn in pairs(http_server.sse_connections) do
-      local sent = conn:send_data(message)
-      if not sent then
-        log.warn(string.format("Dead SSE connection detected, pruning session %s", sid))
-        table.insert(dead_sessions, sid)
-      end
-    end
+    local notifier = Notifier.new({
+      send_fn = function(session_id, msg)
+        return hub:send_to_session(session_id, msg)
+      end,
+      broadcast_fn = function(msg)
+        hub:broadcast(msg)
+      end,
+    })
 
-    -- Prune dead sessions (can't modify table during pairs iteration)
-    if #dead_sessions > 0 then
-      local sse_mgr = sse.SSEManager.get_instance()
-      for _, sid in ipairs(dead_sessions) do
-        sse_mgr:remove_session(sid)
-        http_server.sse_connections[sid] = nil
-      end
-    end
-  end)
-  log.debug("Notify callback wired up for SSE session %s", session_id)
+    local methods = require("buddy.mcp.methods")
+    methods.set_notify_callback(function(notification)
+      notifier:broadcast(notification.method, notification.params)
+    end)
+
+    _notifier_wired = true
+    log.debug("Notifier wired via SSEHub (once)")
+  else
+    -- Ensure hub has latest http_server reference for new connections
+    local SSEHub = require("buddy.transport.sse.hub")
+    SSEHub.get_instance(http_server)
+  end
 
   log.debug(string.format("SSE session created: %s", session_id))
 end
@@ -241,6 +240,11 @@ function M._handle_404(http_server, client, request)
     {["Content-Type"] = "application/json"},
     response
   )
+end
+
+--- Reset internal state (for testing)
+function M._reset()
+  _notifier_wired = false
 end
 
 return M

--- a/lua/buddy/server/router.lua
+++ b/lua/buddy/server/router.lua
@@ -52,28 +52,37 @@ function M._handle_sse(http_server, client, _request)
 
   http_server.sse_connections[session_id] = sse_conn
 
-  -- Wire up notify callback on first SSE connection to broadcast to all sessions
+  -- Wire up notify callback to broadcast to all sessions
   local methods = require("buddy.mcp.methods")
-  if not methods._notify_callback then
-    methods.set_notify_callback(function(notification)
-      local message = {
-        jsonrpc = "2.0",
-        method = notification.method,
-      }
-      if notification.params then
-        message.params = notification.params
-      end
+  methods.set_notify_callback(function(notification)
+    local message = {
+      jsonrpc = "2.0",
+      method = notification.method,
+    }
+    if notification.params then
+      message.params = notification.params
+    end
 
-      -- Broadcast to all active SSE connections
-      for sid, conn in pairs(http_server.sse_connections) do
-        local sent = conn:send_data(message)
-        if not sent then
-          log.debug(string.format("Failed to broadcast notification to session %s", sid))
-        end
+    -- Broadcast to all active SSE connections
+    local dead_sessions = {}
+    for sid, conn in pairs(http_server.sse_connections) do
+      local sent = conn:send_data(message)
+      if not sent then
+        log.warn(string.format("Dead SSE connection detected, pruning session %s", sid))
+        table.insert(dead_sessions, sid)
       end
-    end)
-    log.debug("Hot reload notifications wired up")
-  end
+    end
+
+    -- Prune dead sessions (can't modify table during pairs iteration)
+    if #dead_sessions > 0 then
+      local sse_mgr = sse.SSEManager.get_instance()
+      for _, sid in ipairs(dead_sessions) do
+        sse_mgr:remove_session(sid)
+        http_server.sse_connections[sid] = nil
+      end
+    end
+  end)
+  log.debug("Notify callback wired up for SSE session %s", session_id)
 
   log.debug(string.format("SSE session created: %s", session_id))
 end

--- a/lua/buddy/server/sse.lua
+++ b/lua/buddy/server/sse.lua
@@ -94,6 +94,16 @@ function SSEManager.get_instance()
   return instance
 end
 
+--- Emit a runtime event if the buddy event bus is available
+---@param event string
+---@param payload table|nil
+local function _emit(event, payload)
+  local ok, buddy = pcall(require, "buddy")
+  if ok and buddy._runtime then
+    buddy._runtime.event_bus:publish(event, payload)
+  end
+end
+
 function SSEManager:create_session(client, port)
   local session_id = tostring(uv.hrtime())
   local sse_conn = SSEConnection.new(client, session_id)
@@ -104,6 +114,8 @@ function SSEManager:create_session(client, port)
   local endpoint_url = string.format("http://%s:%d/message?sessionId=%s", host, port, session_id)
 
   sse_conn:send_raw_event("endpoint", endpoint_url)
+
+  _emit("session_connected", { session_id = session_id })
 
   return session_id, sse_conn
 end
@@ -117,6 +129,7 @@ function SSEManager:remove_session(session_id)
   if conn then
     conn:close()
     self.sessions[session_id] = nil
+    _emit("session_disconnected", { session_id = session_id })
   end
 end
 

--- a/lua/buddy/server/sse.lua
+++ b/lua/buddy/server/sse.lua
@@ -25,9 +25,10 @@ function SSEConnection:_send_headers()
 
   local response = "HTTP/1.1 200 OK\r\n" .. table.concat(headers, "\r\n") .. "\r\n\r\n"
 
+  local conn = self
   self.client:write(response, vim.schedule_wrap(function(err)
     if err then
-      error(string.format("SSE header write error: %s", err))
+      conn.closed = true
     end
   end))
 end
@@ -41,9 +42,10 @@ function SSEConnection:send_data(data)
   local data_json = vim.json.encode(data)
   local event = string.format("data: %s\n\n", data_json)
 
+  local conn = self
   self.client:write(event, vim.schedule_wrap(function(err)
     if err then
-      error(string.format("SSE data write error: %s", err))
+      conn.closed = true
     end
   end))
 
@@ -57,9 +59,10 @@ function SSEConnection:send_raw_event(event_type, data)
 
   local event = string.format("event: %s\ndata: %s\n\n", event_type, data)
 
+  local conn = self
   self.client:write(event, vim.schedule_wrap(function(err)
     if err then
-      error(string.format("SSE event write error: %s", err))
+      conn.closed = true
     end
   end))
 
@@ -107,6 +110,14 @@ end
 
 function SSEManager:get_session(session_id)
   return self.sessions[session_id]
+end
+
+function SSEManager:remove_session(session_id)
+  local conn = self.sessions[session_id]
+  if conn then
+    conn:close()
+    self.sessions[session_id] = nil
+  end
 end
 
 return {

--- a/lua/buddy/services/client_requester.lua
+++ b/lua/buddy/services/client_requester.lua
@@ -1,0 +1,169 @@
+-- Transport-agnostic server→client request/response handling
+-- Enables sampling, elicitation, and roots requests without SSE coupling
+
+---@class ClientRequester
+---@field _send_fn fun(session_id:string, msg:table):boolean
+---@field _pending table<string, PendingServiceRequest>
+---@field _next_id number
+local ClientRequester = {}
+ClientRequester.__index = ClientRequester
+
+---@class PendingServiceRequest
+---@field session_id string
+---@field resolve fun(result: any)
+---@field reject fun(error: any)
+---@field timer userdata|nil
+
+--- Create a new ClientRequester
+---@param opts table { send_fn: fun(session_id:string, msg:table):boolean }
+---@return ClientRequester
+function ClientRequester.new(opts)
+  assert(opts and opts.send_fn, "ClientRequester requires opts.send_fn")
+  local self = setmetatable({}, ClientRequester)
+  self._send_fn = opts.send_fn
+  self._pending = {}
+  self._next_id = 1
+  return self
+end
+
+--- Generate unique request ID
+---@return string
+function ClientRequester:_generate_id()
+  local id = "srv_" .. self._next_id
+  self._next_id = self._next_id + 1
+  return id
+end
+
+--- Send a synchronous request to client (blocks via vim.wait)
+---@param session_id string
+---@param method string
+---@param params table
+---@param timeout_ms? number Default 30000
+---@return any result
+---@return string|nil error
+function ClientRequester:request_sync(session_id, method, params, timeout_ms)
+  timeout_ms = timeout_ms or 30000
+
+  local id = self:_generate_id()
+  local result, err
+  local done = false
+
+  -- Create pending request entry
+  self._pending[id] = {
+    session_id = session_id,
+    resolve = function(res)
+      result = res
+      done = true
+    end,
+    reject = function(e)
+      err = e
+      done = true
+    end,
+    timer = nil,
+  }
+
+  -- Set timeout
+  self._pending[id].timer = vim.uv.new_timer()
+  self._pending[id].timer:start(timeout_ms, 0, vim.schedule_wrap(function()
+    if self._pending[id] then
+      self._pending[id].reject({ code = -32000, message = "Request timeout" })
+      self:_cleanup(id)
+    end
+  end))
+
+  -- Send request via injected transport
+  local request = {
+    jsonrpc = "2.0",
+    id = id,
+    method = method,
+    params = params or {},
+  }
+
+  local ok = self._send_fn(session_id, request)
+  if not ok then
+    self:_cleanup(id)
+    return nil, "Failed to send request"
+  end
+
+  -- Block until response or timeout
+  vim.wait(timeout_ms + 100, function() return done end, 10)
+
+  if not done then
+    self:_cleanup(id)
+    return nil, "Request timeout"
+  end
+
+  return result, err
+end
+
+--- Check if a message is a response to a pending request
+---@param msg table JSON-RPC message
+---@return boolean
+function ClientRequester:is_response(msg)
+  return msg.id ~= nil and self._pending[msg.id] ~= nil
+end
+
+--- Handle a response message from client
+---@param msg table JSON-RPC response
+function ClientRequester:handle_response(msg)
+  if msg.error then
+    self:_reject(msg.id, msg.error)
+  else
+    self:_resolve(msg.id, msg.result)
+  end
+end
+
+--- Resolve a pending request
+---@param id string Request ID
+---@param result any
+function ClientRequester:_resolve(id, result)
+  local req = self._pending[id]
+  if req then
+    req.resolve(result)
+    self:_cleanup(id)
+  end
+end
+
+--- Reject a pending request
+---@param id string Request ID
+---@param error any
+function ClientRequester:_reject(id, error)
+  local req = self._pending[id]
+  if req then
+    req.reject(error)
+    self:_cleanup(id)
+  end
+end
+
+--- Cleanup a pending request
+---@param id string
+function ClientRequester:_cleanup(id)
+  local req = self._pending[id]
+  if req then
+    if req.timer then
+      req.timer:stop()
+      req.timer:close()
+    end
+    self._pending[id] = nil
+  end
+end
+
+--- Cleanup all pending requests for a session
+---@param session_id string
+function ClientRequester:cleanup_session(session_id)
+  local to_cleanup = {}
+  for id, req in pairs(self._pending) do
+    if req.session_id == session_id then
+      table.insert(to_cleanup, id)
+    end
+  end
+  for _, id in ipairs(to_cleanup) do
+    local req = self._pending[id]
+    if req then
+      req.reject({ code = -32000, message = "Session closed" })
+    end
+    self:_cleanup(id)
+  end
+end
+
+return ClientRequester

--- a/lua/buddy/services/notifier.lua
+++ b/lua/buddy/services/notifier.lua
@@ -1,0 +1,64 @@
+-- Transport-agnostic protocol notification delivery
+-- Sends MCP notifications to connected clients without SSE coupling
+
+---@class Notifier
+---@field _send_fn fun(session_id:string, msg:table):boolean
+---@field _broadcast_fn? fun(msg:table) Optional broadcast-to-all function
+local Notifier = {}
+Notifier.__index = Notifier
+
+--- Create a new Notifier
+---@param opts table { send_fn: fun(session_id:string, msg:table):boolean, broadcast_fn?: fun(msg:table) }
+---@return Notifier
+function Notifier.new(opts)
+  assert(opts and opts.send_fn, "Notifier requires opts.send_fn")
+  local self = setmetatable({}, Notifier)
+  self._send_fn = opts.send_fn
+  self._broadcast_fn = opts.broadcast_fn
+  return self
+end
+
+--- Send a notification to a specific session
+---@param session_id string
+---@param method string
+---@param params? table
+---@return boolean success
+function Notifier:notify(session_id, method, params)
+  local message = {
+    jsonrpc = "2.0",
+    method = method,
+  }
+  if params then
+    message.params = params
+  end
+  return self._send_fn(session_id, message)
+end
+
+--- Broadcast a notification to multiple sessions
+--- When session_ids is nil, uses broadcast_fn if available (broadcasts to all connected sessions)
+---@param method string
+---@param params? table
+---@param session_ids? string[] Specific sessions, or nil for all
+function Notifier:broadcast(method, params, session_ids)
+  local message = {
+    jsonrpc = "2.0",
+    method = method,
+  }
+  if params then
+    message.params = params
+  end
+
+  -- If no specific sessions, use broadcast_fn for "all sessions" delivery
+  if not session_ids then
+    if self._broadcast_fn then
+      self._broadcast_fn(message)
+    end
+    return
+  end
+
+  for _, session_id in ipairs(session_ids) do
+    self._send_fn(session_id, message)
+  end
+end
+
+return Notifier

--- a/lua/buddy/sessions.lua
+++ b/lua/buddy/sessions.lua
@@ -241,6 +241,7 @@ function M.register(info)
     pid = vim.fn.getpid(),
     cwd = vim.fn.getcwd(),
     label = nil,
+    auth_token = info.auth_token,  -- Bearer token for HTTP auth (nil if auth disabled)
     started_at = os.time(),
     last_seen = os.time(),
   }

--- a/lua/buddy/tools/builtin/edit.lua
+++ b/lua/buddy/tools/builtin/edit.lua
@@ -47,11 +47,8 @@ return {
     -- Convert content to table if it's a string
     local lines = args.content
     if type(lines) == "string" then
-      -- Split string by newline
-      lines = {}
-      for l in string.gmatch(args.content, "[^\n]+") do
-        table.insert(lines, l)
-      end
+      -- Split string by newline (preserving empty lines)
+      lines = vim.split(args.content, "\n", { plain = true })
     elseif not lines then
       lines = {}
     end

--- a/lua/buddy/tools/builtin/grep.lua
+++ b/lua/buddy/tools/builtin/grep.lua
@@ -29,6 +29,11 @@ return {
     local file_pattern = args.file_pattern or "**/*"
     local search_path = args.path
 
+    -- Validate pattern (same as TS)
+    if pattern == "" then
+      return { success = false, error = "Grep pattern cannot be empty" }
+    end
+
     -- If path provided, temporarily cd to it
     local old_cwd = nil
     if search_path and search_path ~= "" then
@@ -37,11 +42,6 @@ return {
       if not ok then
         return { success = false, error = "Invalid path: " .. search_path }
       end
-    end
-
-    -- Validate pattern (same as TS)
-    if pattern == "" then
-      return { success = false, error = "Grep pattern cannot be empty" }
     end
 
     -- Escape forward slashes in pattern to prevent command injection

--- a/lua/buddy/tools/builtin/tab.lua
+++ b/lua/buddy/tools/builtin/tab.lua
@@ -49,7 +49,11 @@ return {
       return { success = true, tabs = result }
 
     elseif args.action == "new" then
-      vim.cmd("tabnew " .. (args.file or ""))
+      if args.file then
+        vim.cmd({ cmd = "tabnew", args = { args.file } })
+      else
+        vim.cmd("tabnew")
+      end
       return { success = true }
 
     elseif args.action == "close" then
@@ -68,7 +72,7 @@ return {
       if not args.tabnr then
         return { success = false, error = "tabnr required for goto action" }
       end
-      vim.cmd("tabn " .. args.tabnr)
+      vim.cmd({ cmd = "tabnext", args = { tonumber(args.tabnr) } })
       return { success = true, tabnr = args.tabnr }
 
     elseif args.action == "first" then

--- a/lua/buddy/tools/executor.lua
+++ b/lua/buddy/tools/executor.lua
@@ -41,9 +41,16 @@ function M.execute(tool_id, args, opts)
     errors.throw(errors.codes.EXECUTION_ERROR, "Tool has no run function: " .. tool_id)
   end
 
-  -- Validate input against schema (new format: tool.args and tool.required)
+  -- Validate input against schema (supports both formats)
   local schema = nil
-  if tool.args then
+  if tool.input_schema then
+    -- New format: tool.input_schema has { type, properties, required }
+    schema = {
+      properties = tool.input_schema.properties,
+      required = tool.input_schema.required,
+    }
+  elseif tool.args then
+    -- Legacy format: tool.args and tool.required
     schema = {
       properties = tool.args,
       required = tool.required,

--- a/lua/buddy/tools/hotreload.lua
+++ b/lua/buddy/tools/hotreload.lua
@@ -97,6 +97,7 @@ function M.untrack_plugin(prefix)
   -- Stop watcher if exists
   if plugin.watcher then
     plugin.watcher:stop()
+    plugin.watcher:close()
     plugin.watcher = nil
   end
 
@@ -181,6 +182,7 @@ function M._start_watcher(prefix)
   -- Stop existing watcher
   if plugin.watcher then
     plugin.watcher:stop()
+    plugin.watcher:close()
     plugin.watcher = nil
   end
 
@@ -208,6 +210,7 @@ function M._start_watcher(prefix)
   if not ok then
     log.warn("Failed to start watcher for %s at %s", prefix, plugin.lua_dir)
     watcher:stop()
+    watcher:close()
     return
   end
 
@@ -224,6 +227,7 @@ function M._stop_watcher(prefix)
   end
 
   plugin.watcher:stop()
+  plugin.watcher:close()
   plugin.watcher = nil
   log.debug("Stopped watcher for %s", prefix)
 end

--- a/lua/buddy/transport/sse/hub.lua
+++ b/lua/buddy/transport/sse/hub.lua
@@ -1,0 +1,95 @@
+-- SSE Hub: Thin adapter over existing SSEManager
+-- Provides transport-agnostic send interface for services
+
+local log = require("buddy.log")
+
+---@class SSEHub
+---@field _manager table SSEManager instance
+---@field _http_server table|nil Reference to http_server for connection tracking
+local SSEHub = {}
+SSEHub.__index = SSEHub
+
+local _instance = nil
+
+--- Get or create the singleton SSEHub
+---@param http_server? table HTTP server instance (for connection tracking)
+---@return SSEHub
+function SSEHub.get_instance(http_server)
+  if not _instance then
+    local sse = require("buddy.server.sse")
+    _instance = setmetatable({}, SSEHub)
+    _instance._manager = sse.SSEManager.get_instance()
+    _instance._http_server = http_server
+  end
+  if http_server then
+    _instance._http_server = http_server
+  end
+  return _instance
+end
+
+--- Reset singleton (for testing)
+function SSEHub.reset()
+  _instance = nil
+end
+
+--- Send a message to a specific session
+---@param session_id string
+---@param msg table JSON-RPC message
+---@return boolean success
+function SSEHub:send_to_session(session_id, msg)
+  local conn = self._manager:get_session(session_id)
+  if not conn then
+    return false
+  end
+  return conn:send_data(msg)
+end
+
+--- Broadcast a message to multiple sessions or all active sessions
+---@param msg table JSON-RPC message
+---@param session_ids? string[] Specific sessions, or nil for all
+function SSEHub:broadcast(msg, session_ids)
+  local targets = session_ids
+
+  -- If no specific sessions, broadcast to all known connections
+  if not targets then
+    targets = {}
+    if self._http_server and self._http_server.sse_connections then
+      for sid, _ in pairs(self._http_server.sse_connections) do
+        table.insert(targets, sid)
+      end
+    end
+  end
+
+  local dead_sessions = {}
+  for _, sid in ipairs(targets) do
+    local ok = self:send_to_session(sid, msg)
+    if not ok then
+      log.warn("Dead SSE connection detected, pruning session %s", sid)
+      table.insert(dead_sessions, sid)
+    end
+  end
+
+  -- Prune dead sessions
+  if #dead_sessions > 0 then
+    for _, sid in ipairs(dead_sessions) do
+      self._manager:remove_session(sid)
+      if self._http_server and self._http_server.sse_connections then
+        self._http_server.sse_connections[sid] = nil
+      end
+    end
+  end
+end
+
+--- Get all active session IDs
+---@return string[]
+function SSEHub:get_session_ids()
+  local ids = {}
+  if self._http_server and self._http_server.sse_connections then
+    for sid, _ in pairs(self._http_server.sse_connections) do
+      table.insert(ids, sid)
+    end
+  end
+  return ids
+end
+
+return SSEHub

--- a/mcp/buddy-mcp-proxy/README.md
+++ b/mcp/buddy-mcp-proxy/README.md
@@ -18,44 +18,50 @@ MCP proxy server for buddy.nvim sessions. This proxy allows OpenCode (or any MCP
 ## Installation
 
 ```bash
-cd mcp/buddy-mcp-proxy
-bun install
-bun run build
+npm install -g buddy-mcp-proxy
 ```
+
+Or use it directly with `npx` — no install needed (see Usage below).
 
 ## Usage
 
 ### With OpenCode
 
-Update `~/.config/opencode/opencode.jsonc`:
+Add to `~/.config/opencode/opencode.jsonc`:
 
 ```jsonc
 {
   "mcp": {
     "vim": {
       "type": "local",
-      "command": [
-        "node",
-        "/home/ari/Work/tries/2026-01-26-nvim-buddy-v3/mcp/buddy-mcp-proxy/dist/index.js"
-      ]
+      "command": ["npx", "buddy-mcp-proxy"]
     }
   }
 }
 ```
 
-Or using bunx (if published):
+### With Claude Desktop
+
+Add to your Claude Desktop MCP config:
 
 ```json
 {
-  "mcp": {
-    "servers": {
-      "buddy": {
-        "command": "bunx",
-        "args": ["buddy-mcp-proxy"]
-      }
+  "mcpServers": {
+    "vim": {
+      "command": "npx",
+      "args": ["buddy-mcp-proxy"]
     }
   }
 }
+```
+
+### From Source
+
+```bash
+cd mcp/buddy-mcp-proxy
+npm install
+npm run build
+node dist/index.js
 ```
 
 ### Development
@@ -65,10 +71,10 @@ Or using bunx (if published):
 bun run dev
 
 # Build for production
-bun run build
+npm run build
 
 # Type check
-bun run typecheck
+npm run typecheck
 ```
 
 ## Sessions Registry Format

--- a/mcp/buddy-mcp-proxy/dist/index.js
+++ b/mcp/buddy-mcp-proxy/dist/index.js
@@ -7,11 +7,15 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   CallToolRequestSchema,
-  ListToolsRequestSchema
+  ListToolsRequestSchema,
+  ToolListChangedNotificationSchema
 } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+var execFileAsync = promisify(execFile);
 function log(level, msg, data) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
   const line = `[${timestamp}] [${level.toUpperCase()}] ${msg}`;
@@ -115,6 +119,71 @@ function resolveSession(sessions, selector) {
   }
   return null;
 }
+var buddyInstallStatus = null;
+var buddyInstallCheckPromise = null;
+async function checkBuddyInstalled() {
+  if (buddyInstallStatus !== null) {
+    return buddyInstallStatus;
+  }
+  if (!buddyInstallCheckPromise) {
+    buddyInstallCheckPromise = (async () => {
+      try {
+        const { stdout } = await execFileAsync("nvim", [
+          "--headless",
+          "-c",
+          `lua local ok,_=pcall(require,'buddy'); print(ok and 'BUDDY_OK' or 'BUDDY_MISSING')`,
+          "-c",
+          "qa!"
+        ], { timeout: 1e4 });
+        if (stdout.includes("BUDDY_OK")) {
+          buddyInstallStatus = "installed";
+          log("info", "buddy.nvim install check: installed");
+        } else {
+          buddyInstallStatus = "missing";
+          log("warn", "buddy.nvim install check: NOT installed");
+        }
+      } catch (err) {
+        log("error", "buddy.nvim install check failed (nvim not found?)", err);
+        buddyInstallStatus = "check_failed";
+      }
+      buddyInstallCheckPromise = null;
+      return buddyInstallStatus;
+    })();
+  }
+  return buddyInstallCheckPromise;
+}
+async function getNoSessionsHint() {
+  const sessionsPath = getSessionsPath();
+  const status = await checkBuddyInstalled();
+  const lines = [];
+  lines.push("");
+  lines.push("\u2500\u2500 Troubleshooting \u2500\u2500");
+  if (status === "missing") {
+    lines.push("\u2717 buddy.nvim is NOT installed in Neovim.");
+    lines.push("  Install it first: https://github.com/arismoko/buddy.nvim#installation");
+  } else if (status === "installed") {
+    lines.push("\u2713 buddy.nvim is installed in Neovim.");
+    lines.push("");
+    lines.push("To start a buddy server, do ONE of:");
+    lines.push("  \u2022 Open Neovim with auto_start enabled:");
+    lines.push('      require("buddy").setup({ auto_start = true })');
+    lines.push("  \u2022 Or start manually inside Neovim:");
+    lines.push('      :lua require("buddy").start()');
+  } else {
+    lines.push("? Could not detect whether buddy.nvim is installed (nvim not found on PATH).");
+    lines.push("");
+    lines.push("If buddy.nvim is installed, start a server:");
+    lines.push("  \u2022 Open Neovim with auto_start enabled:");
+    lines.push('      require("buddy").setup({ auto_start = true })');
+    lines.push("  \u2022 Or start manually inside Neovim:");
+    lines.push('      :lua require("buddy").start()');
+  }
+  lines.push("");
+  lines.push(`Sessions file: ${sessionsPath}`);
+  const exists = fs.existsSync(sessionsPath);
+  lines.push(`  ${exists ? "\u2713 File exists" : "\u2717 File does not exist (no session has ever started)"}`);
+  return lines.join("\n");
+}
 var META_TOOLS = [
   {
     name: "buddy_sessions_list",
@@ -179,6 +248,10 @@ var DownstreamManager = class {
   transport = null;
   currentSession = null;
   cachedTools = [];
+  onToolsChanged = null;
+  setOnToolsChanged(cb) {
+    this.onToolsChanged = cb;
+  }
   async connect(session) {
     await this.disconnect();
     const url = `http://${session.host || "127.0.0.1"}:${session.port}/sse`;
@@ -191,6 +264,16 @@ var DownstreamManager = class {
       );
       await this.client.connect(this.transport);
       this.currentSession = session;
+      this.client.setNotificationHandler(
+        ToolListChangedNotificationSchema,
+        async () => {
+          log("info", "Downstream tools changed, refreshing...");
+          await this.refreshTools();
+          if (this.onToolsChanged) {
+            await this.onToolsChanged();
+          }
+        }
+      );
       await this.refreshTools();
       log("info", `Connected to session ${session.id} on port ${session.port}`);
     } catch (err) {
@@ -279,6 +362,75 @@ var DownstreamManager = class {
     return this.client !== null && this.currentSession !== null;
   }
 };
+var SessionPoller = class _SessionPoller {
+  static BACKOFF_MS = 3e4;
+  timer = null;
+  connecting = false;
+  failedSessions = /* @__PURE__ */ new Map();
+  intervalMs;
+  downstream;
+  onConnected;
+  constructor(opts) {
+    this.downstream = opts.downstream;
+    this.intervalMs = opts.intervalMs ?? 3e3;
+    this.onConnected = opts.onConnected;
+  }
+  start() {
+    if (this.timer)
+      return;
+    log("info", `Session poller started (every ${this.intervalMs}ms)`);
+    this.timer = setInterval(() => this.poll(), this.intervalMs);
+    this.poll();
+  }
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      log("info", "Session poller stopped");
+    }
+  }
+  /** Restart polling (e.g. after a disconnect) */
+  ensure() {
+    if (!this.downstream.isConnected() && !this.timer) {
+      this.start();
+    }
+  }
+  async poll() {
+    if (this.downstream.isConnected() || this.connecting)
+      return;
+    const sessions = loadSessions();
+    if (sessions.length === 0)
+      return;
+    const sorted = [...sessions].sort(
+      (a, b) => (b.last_seen ?? 0) - (a.last_seen ?? 0)
+    );
+    const now = Date.now();
+    let candidates = sorted.filter((s) => {
+      const failedAt = this.failedSessions.get(s.id);
+      return failedAt === void 0 || now - failedAt >= _SessionPoller.BACKOFF_MS;
+    });
+    if (candidates.length === 0) {
+      log("info", "All sessions in backoff \u2014 clearing failed set and retrying");
+      this.failedSessions.clear();
+      candidates = sorted;
+    }
+    const target = candidates[0];
+    this.connecting = true;
+    try {
+      log("info", `Auto-connecting to session ${target.id} (port ${target.port})`);
+      await this.downstream.connect(target);
+      this.failedSessions.clear();
+      this.stop();
+      await this.onConnected();
+      log("info", `Auto-connected to session ${target.id}`);
+    } catch (err) {
+      this.failedSessions.set(target.id, Date.now());
+      log("warn", `Auto-connect to ${target.id} failed (backoff ${_SessionPoller.BACKOFF_MS}ms), will try next session`, err);
+    } finally {
+      this.connecting = false;
+    }
+  }
+};
 async function main() {
   log("info", "Starting buddy-mcp-proxy");
   const downstream = new DownstreamManager();
@@ -296,6 +448,12 @@ async function main() {
       log("error", "Failed to send tools/list_changed notification", err);
     }
   };
+  downstream.setOnToolsChanged(notifyToolsChanged);
+  const poller = new SessionPoller({
+    downstream,
+    onConnected: notifyToolsChanged
+  });
+  poller.start();
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     if (downstream.isConnected()) {
       await downstream.checkHealth();
@@ -314,6 +472,18 @@ async function main() {
     if (name === "buddy_sessions_list") {
       const sessions = loadSessions();
       const currentId = downstream.getCurrentSession()?.id;
+      if (sessions.length === 0) {
+        const hint = await getNoSessionsHint();
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No buddy.nvim sessions found.
+${hint}`
+            }
+          ]
+        };
+      }
       return {
         content: [
           {
@@ -362,11 +532,15 @@ async function main() {
       const sessions = loadSessions();
       const session = resolveSession(sessions, selector);
       if (!session) {
+        const hint = sessions.length === 0 ? await getNoSessionsHint() : "";
+        const availableInfo = sessions.length > 0 ? `
+Available sessions:
+${sessions.map((s) => `  \u2022 ${s.id} (cwd: ${s.cwd}${s.label ? `, label: ${s.label}` : ""})`).join("\n")}` : "";
         return {
           content: [
             {
               type: "text",
-              text: `Error: Session not found for selector ${JSON.stringify(selector)}`
+              text: `Error: Session not found for selector ${JSON.stringify(selector)}${availableInfo}${hint}`
             }
           ],
           isError: true
@@ -374,6 +548,7 @@ async function main() {
       }
       try {
         await downstream.connect(session);
+        poller.stop();
         await notifyToolsChanged();
         return {
           content: [
@@ -437,12 +612,14 @@ async function main() {
             try {
               await downstream.connect(stillExists);
             } catch {
+              poller.ensure();
             }
           } else {
             await downstream.refreshTools();
           }
         } else {
           await downstream.disconnect();
+          poller.ensure();
         }
         await notifyToolsChanged();
       }
@@ -465,11 +642,21 @@ async function main() {
       };
     }
     if (!downstream.isConnected()) {
+      const sessions = loadSessions();
+      let hint;
+      if (sessions.length === 0) {
+        hint = await getNoSessionsHint();
+      } else {
+        hint = `
+
+Available sessions (use buddy_session_select to connect):
+${sessions.sort((a, b) => (b.last_seen ?? 0) - (a.last_seen ?? 0)).map((s) => `  \u2022 ${s.id} (cwd: ${s.cwd}${s.label ? `, label: ${s.label}` : ""})`).join("\n")}`;
+      }
       return {
         content: [
           {
             type: "text",
-            text: `Error: No buddy.nvim session selected. Use buddy_sessions_list and buddy_session_select first.`
+            text: `Error: No buddy.nvim session selected. Use buddy_sessions_list and buddy_session_select first.${hint}`
           }
         ],
         isError: true
@@ -481,6 +668,7 @@ async function main() {
     } catch (err) {
       if (!downstream.isConnected()) {
         await notifyToolsChanged();
+        poller.ensure();
       }
       return {
         content: [
@@ -498,12 +686,14 @@ async function main() {
   log("info", "buddy-mcp-proxy running on stdio");
   process.on("SIGINT", async () => {
     log("info", "Shutting down...");
+    poller.stop();
     await downstream.disconnect();
     await server.close();
     process.exit(0);
   });
   process.on("SIGTERM", async () => {
     log("info", "Shutting down...");
+    poller.stop();
     await downstream.disconnect();
     await server.close();
     process.exit(0);

--- a/mcp/buddy-mcp-proxy/dist/index.js
+++ b/mcp/buddy-mcp-proxy/dist/index.js
@@ -58,6 +58,7 @@ function normalizeSessions(raw) {
           cwd,
           label: s.label ?? null,
           pid: typeof s.pid === "number" ? s.pid : void 0,
+          auth_token: typeof s.auth_token === "string" ? s.auth_token : void 0,
           started_at: s.started_at,
           last_seen: typeof s.last_seen === "number" ? s.last_seen : void 0
         }
@@ -257,7 +258,15 @@ var DownstreamManager = class {
     const url = `http://${session.host || "127.0.0.1"}:${session.port}/sse`;
     log("info", `Connecting to downstream: ${url}`);
     try {
-      this.transport = new SSEClientTransport(new URL(url));
+      const transportOpts = {};
+      if (session.auth_token) {
+        transportOpts.requestInit = {
+          headers: {
+            "Authorization": `Bearer ${session.auth_token}`
+          }
+        };
+      }
+      this.transport = new SSEClientTransport(new URL(url), transportOpts);
       this.client = new Client(
         { name: "buddy-mcp-proxy", version: "0.1.0" },
         { capabilities: {} }

--- a/mcp/buddy-mcp-proxy/package.json
+++ b/mcp/buddy-mcp-proxy/package.json
@@ -1,17 +1,46 @@
 {
   "name": "buddy-mcp-proxy",
   "version": "0.1.0",
-  "description": "MCP proxy server for buddy.nvim sessions",
+  "description": "MCP proxy server for buddy.nvim — connect AI agents to Neovim sessions",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
     "buddy-mcp-proxy": "dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "start": "node dist/index.js",
     "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/index.js --banner:js='#!/usr/bin/env node' --packages=external",
+    "prepublishOnly": "npm run build",
     "dev": "bun run src/index.ts",
     "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "mcp",
+    "neovim",
+    "nvim",
+    "buddy",
+    "ai",
+    "model-context-protocol",
+    "editor",
+    "proxy"
+  ],
+  "author": "arismoko",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arismoko/buddy.nvim.git",
+    "directory": "mcp/buddy-mcp-proxy"
+  },
+  "homepage": "https://github.com/arismoko/buddy.nvim/tree/main/mcp/buddy-mcp-proxy",
+  "bugs": {
+    "url": "https://github.com/arismoko/buddy.nvim/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"

--- a/mcp/buddy-mcp-proxy/src/index.ts
+++ b/mcp/buddy-mcp-proxy/src/index.ts
@@ -28,6 +28,7 @@ interface BuddySession {
   cwd: string;
   label?: string | null;
   pid?: number;
+  auth_token?: string | null;
   started_at?: number | string;
   last_seen?: number;
 }
@@ -97,6 +98,7 @@ function normalizeSessions(raw: unknown): BuddySession[] {
           cwd,
           label: (s as any).label ?? null,
           pid: typeof (s as any).pid === "number" ? (s as any).pid : undefined,
+          auth_token: typeof (s as any).auth_token === "string" ? (s as any).auth_token : undefined,
           started_at: (s as any).started_at,
           last_seen: typeof (s as any).last_seen === "number" ? (s as any).last_seen : undefined,
           } satisfies BuddySession,
@@ -339,7 +341,16 @@ class DownstreamManager {
     log("info", `Connecting to downstream: ${url}`);
 
     try {
-      this.transport = new SSEClientTransport(new URL(url));
+      // Pass auth token as Bearer header if available
+      const transportOpts: { requestInit?: RequestInit } = {};
+      if (session.auth_token) {
+        transportOpts.requestInit = {
+          headers: {
+            "Authorization": `Bearer ${session.auth_token}`,
+          },
+        };
+      }
+      this.transport = new SSEClientTransport(new URL(url), transportOpts);
       this.client = new Client(
         { name: "buddy-mcp-proxy", version: "0.1.0" },
         { capabilities: {} }

--- a/mcp/buddy-mcp-proxy/src/index.ts
+++ b/mcp/buddy-mcp-proxy/src/index.ts
@@ -615,7 +615,10 @@ async function main() {
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     // Check downstream health before listing
     if (downstream.isConnected()) {
-      await downstream.checkHealth();
+      const healthy = await downstream.checkHealth();
+      if (!healthy) {
+        poller.ensure(); // Resume polling after health-check disconnect
+      }
     }
 
     const downstreamTools = downstream.getTools();

--- a/mcp/buddy-mcp-proxy/src/index.ts
+++ b/mcp/buddy-mcp-proxy/src/index.ts
@@ -6,11 +6,16 @@ import {
   CallToolRequestSchema,
   CallToolResult,
   ListToolsRequestSchema,
+  ToolListChangedNotificationSchema,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -164,6 +169,87 @@ function resolveSession(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Plugin Install Check
+// ─────────────────────────────────────────────────────────────────────────────
+
+let buddyInstallStatus: "installed" | "missing" | "check_failed" | null = null;
+let buddyInstallCheckPromise: Promise<"installed" | "missing" | "check_failed"> | null = null;
+
+async function checkBuddyInstalled(): Promise<"installed" | "missing" | "check_failed"> {
+  if (buddyInstallStatus !== null) {
+    return buddyInstallStatus;
+  }
+
+  // Deduplicate concurrent checks — share one in-flight promise
+  if (!buddyInstallCheckPromise) {
+    buddyInstallCheckPromise = (async (): Promise<"installed" | "missing" | "check_failed"> => {
+      try {
+        const { stdout } = await execFileAsync("nvim", [
+          "--headless",
+          "-c",
+          `lua local ok,_=pcall(require,'buddy'); print(ok and 'BUDDY_OK' or 'BUDDY_MISSING')`,
+          "-c",
+          "qa!",
+        ], { timeout: 10_000 });
+
+        if (stdout.includes("BUDDY_OK")) {
+          buddyInstallStatus = "installed";
+          log("info", "buddy.nvim install check: installed");
+        } else {
+          buddyInstallStatus = "missing";
+          log("warn", "buddy.nvim install check: NOT installed");
+        }
+      } catch (err) {
+        log("error", "buddy.nvim install check failed (nvim not found?)", err);
+        buddyInstallStatus = "check_failed";
+      }
+      buddyInstallCheckPromise = null;
+      return buddyInstallStatus!;
+    })();
+  }
+
+  return buddyInstallCheckPromise;
+}
+
+async function getNoSessionsHint(): Promise<string> {
+  const sessionsPath = getSessionsPath();
+  const status = await checkBuddyInstalled();
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("── Troubleshooting ──");
+
+  if (status === "missing") {
+    lines.push("✗ buddy.nvim is NOT installed in Neovim.");
+    lines.push("  Install it first: https://github.com/arismoko/buddy.nvim#installation");
+  } else if (status === "installed") {
+    lines.push("✓ buddy.nvim is installed in Neovim.");
+    lines.push("");
+    lines.push("To start a buddy server, do ONE of:");
+    lines.push("  • Open Neovim with auto_start enabled:");
+    lines.push('      require("buddy").setup({ auto_start = true })');
+    lines.push("  • Or start manually inside Neovim:");
+    lines.push('      :lua require("buddy").start()');
+  } else {
+    // check_failed — nvim not on PATH or timed out
+    lines.push("? Could not detect whether buddy.nvim is installed (nvim not found on PATH).");
+    lines.push("");
+    lines.push("If buddy.nvim is installed, start a server:");
+    lines.push("  • Open Neovim with auto_start enabled:");
+    lines.push('      require("buddy").setup({ auto_start = true })');
+    lines.push("  • Or start manually inside Neovim:");
+    lines.push('      :lua require("buddy").start()');
+  }
+
+  lines.push("");
+  lines.push(`Sessions file: ${sessionsPath}`);
+  const exists = fs.existsSync(sessionsPath);
+  lines.push(`  ${exists ? "✓ File exists" : "✗ File does not exist (no session has ever started)"}`);
+
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Meta Tools Definition
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -240,6 +326,11 @@ class DownstreamManager {
   private transport: SSEClientTransport | null = null;
   private currentSession: BuddySession | null = null;
   private cachedTools: Tool[] = [];
+  private onToolsChanged: (() => Promise<void>) | null = null;
+
+  setOnToolsChanged(cb: () => Promise<void>): void {
+    this.onToolsChanged = cb;
+  }
 
   async connect(session: BuddySession): Promise<void> {
     await this.disconnect();
@@ -256,6 +347,18 @@ class DownstreamManager {
 
       await this.client.connect(this.transport);
       this.currentSession = session;
+
+      // Subscribe to downstream tools/list_changed notifications
+      this.client.setNotificationHandler(
+        ToolListChangedNotificationSchema,
+        async () => {
+          log("info", "Downstream tools changed, refreshing...");
+          await this.refreshTools();
+          if (this.onToolsChanged) {
+            await this.onToolsChanged();
+          }
+        }
+      );
 
       // Fetch and cache tools
       await this.refreshTools();
@@ -372,6 +475,96 @@ class DownstreamManager {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Session Auto-Connect Poller
+// ─────────────────────────────────────────────────────────────────────────────
+
+class SessionPoller {
+  private static readonly BACKOFF_MS = 30_000;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private connecting = false;
+  private failedSessions = new Map<string, number>();
+  private readonly intervalMs: number;
+  private readonly downstream: DownstreamManager;
+  private readonly onConnected: () => Promise<void>;
+
+  constructor(opts: {
+    downstream: DownstreamManager;
+    intervalMs?: number;
+    onConnected: () => Promise<void>;
+  }) {
+    this.downstream = opts.downstream;
+    this.intervalMs = opts.intervalMs ?? 3_000;
+    this.onConnected = opts.onConnected;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    log("info", `Session poller started (every ${this.intervalMs}ms)`);
+    this.timer = setInterval(() => this.poll(), this.intervalMs);
+    // Also poll immediately on start
+    this.poll();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      log("info", "Session poller stopped");
+    }
+  }
+
+  /** Restart polling (e.g. after a disconnect) */
+  ensure(): void {
+    if (!this.downstream.isConnected() && !this.timer) {
+      this.start();
+    }
+  }
+
+  private async poll(): Promise<void> {
+    // Skip if already connected or a connection attempt is in flight
+    if (this.downstream.isConnected() || this.connecting) return;
+
+    const sessions = loadSessions();
+    if (sessions.length === 0) return;
+
+    // Pick the most recently seen session, skipping recently failed ones
+    const sorted = [...sessions].sort(
+      (a, b) => (b.last_seen ?? 0) - (a.last_seen ?? 0)
+    );
+
+    const now = Date.now();
+    let candidates = sorted.filter((s) => {
+      const failedAt = this.failedSessions.get(s.id);
+      return failedAt === undefined || now - failedAt >= SessionPoller.BACKOFF_MS;
+    });
+
+    // If all sessions are in backoff, clear and start over to avoid deadlock
+    if (candidates.length === 0) {
+      log("info", "All sessions in backoff — clearing failed set and retrying");
+      this.failedSessions.clear();
+      candidates = sorted;
+    }
+
+    const target = candidates[0];
+
+    this.connecting = true;
+    try {
+      log("info", `Auto-connecting to session ${target.id} (port ${target.port})`);
+      await this.downstream.connect(target);
+      this.failedSessions.clear(); // Connected — reset failure tracking
+      this.stop(); // Connected — stop polling
+      await this.onConnected();
+      log("info", `Auto-connected to session ${target.id}`);
+    } catch (err) {
+      this.failedSessions.set(target.id, Date.now());
+      log("warn", `Auto-connect to ${target.id} failed (backoff ${SessionPoller.BACKOFF_MS}ms), will try next session`, err);
+    } finally {
+      this.connecting = false;
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // MCP Server
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -396,6 +589,16 @@ async function main() {
       log("error", "Failed to send tools/list_changed notification", err);
     }
   };
+
+  // Wire up downstream → upstream tools changed propagation
+  downstream.setOnToolsChanged(notifyToolsChanged);
+
+  // Auto-connect poller — watches sessions file and connects when one appears
+  const poller = new SessionPoller({
+    downstream,
+    onConnected: notifyToolsChanged,
+  });
+  poller.start();
 
   // Handle tools/list
   server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -425,6 +628,19 @@ async function main() {
     if (name === "buddy_sessions_list") {
       const sessions = loadSessions();
       const currentId = downstream.getCurrentSession()?.id;
+
+      if (sessions.length === 0) {
+        const hint = await getNoSessionsHint();
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `No buddy.nvim sessions found.\n${hint}`,
+            },
+          ],
+        };
+      }
+
       return {
         content: [
           {
@@ -482,11 +698,15 @@ async function main() {
       const session = resolveSession(sessions, selector);
 
       if (!session) {
+        const hint = sessions.length === 0 ? await getNoSessionsHint() : "";
+        const availableInfo = sessions.length > 0
+          ? `\nAvailable sessions:\n${sessions.map((s) => `  • ${s.id} (cwd: ${s.cwd}${s.label ? `, label: ${s.label}` : ""})`).join("\n")}`
+          : "";
         return {
           content: [
             {
               type: "text" as const,
-              text: `Error: Session not found for selector ${JSON.stringify(selector)}`,
+              text: `Error: Session not found for selector ${JSON.stringify(selector)}${availableInfo}${hint}`,
             },
           ],
           isError: true,
@@ -495,6 +715,7 @@ async function main() {
 
       try {
         await downstream.connect(session);
+        poller.stop(); // Connected manually — stop polling
         await notifyToolsChanged();
         return {
           content: [
@@ -566,12 +787,14 @@ async function main() {
               await downstream.connect(stillExists);
             } catch {
               // Connection failed, already disconnected
+              poller.ensure();
             }
           } else {
             await downstream.refreshTools();
           }
         } else {
           await downstream.disconnect();
+          poller.ensure(); // Resume polling after disconnect
         }
         await notifyToolsChanged();
       }
@@ -597,11 +820,21 @@ async function main() {
 
     // Forward to downstream
     if (!downstream.isConnected()) {
+      const sessions = loadSessions();
+      let hint: string;
+      if (sessions.length === 0) {
+        hint = await getNoSessionsHint();
+      } else {
+        hint = `\n\nAvailable sessions (use buddy_session_select to connect):\n${sessions
+          .sort((a, b) => (b.last_seen ?? 0) - (a.last_seen ?? 0))
+          .map((s) => `  • ${s.id} (cwd: ${s.cwd}${s.label ? `, label: ${s.label}` : ""})`)
+          .join("\n")}`;
+      }
       return {
         content: [
           {
             type: "text" as const,
-            text: `Error: No buddy.nvim session selected. Use buddy_sessions_list and buddy_session_select first.`,
+            text: `Error: No buddy.nvim session selected. Use buddy_sessions_list and buddy_session_select first.${hint}`,
           },
         ],
         isError: true,
@@ -612,9 +845,10 @@ async function main() {
       const result = await downstream.callTool(name, args as Record<string, unknown>);
       return result;
     } catch (err) {
-      // If downstream died, notify
+      // If downstream died, notify and resume polling
       if (!downstream.isConnected()) {
         await notifyToolsChanged();
+        poller.ensure();
       }
       return {
         content: [
@@ -637,6 +871,7 @@ async function main() {
   // Handle shutdown
   process.on("SIGINT", async () => {
     log("info", "Shutting down...");
+    poller.stop();
     await downstream.disconnect();
     await server.close();
     process.exit(0);
@@ -644,6 +879,7 @@ async function main() {
 
   process.on("SIGTERM", async () => {
     log("info", "Shutting down...");
+    poller.stop();
     await downstream.disconnect();
     await server.close();
     process.exit(0);

--- a/plugin/buddy.lua
+++ b/plugin/buddy.lua
@@ -25,10 +25,6 @@ vim.api.nvim_create_user_command("BuddyStatus", function()
   end
 end, { desc = "Show buddy status" })
 
-vim.api.nvim_create_user_command("BuddyInstallExamples", function()
-  require("buddy").reinstall_examples()
-end, { desc = "Reinstall buddy example tools" })
-
 vim.api.nvim_create_user_command("BuddyReloadTools", function()
   require("buddy.tools.discovery").reload_all()
   print("[buddy] All tools reloaded")

--- a/plugins/buddy_viz/lua/buddy_viz/helpers.lua
+++ b/plugins/buddy_viz/lua/buddy_viz/helpers.lua
@@ -3,9 +3,16 @@
 
 local M = {}
 
-local stdout = vim.loop.new_tty(1, false)
-if not stdout then
-  error("failed to open stdout")
+local stdout = nil
+
+local function get_stdout()
+  if not stdout then
+    stdout = vim.loop.new_tty(1, false)
+    if not stdout then
+      return nil
+    end
+  end
+  return stdout
 end
 
 local uv = vim.uv or vim.loop
@@ -48,7 +55,8 @@ local DEBOUNCE_MS = 50
 local keypress_state = { o_x = 0, o_y = 0, zoom = 0 }
 
 local function delete_kitty_image()
-  stdout:write("\27_Ga=d\27\\")
+  local out = get_stdout()
+  if out then out:write("\27_Ga=d\27\\") end
 end
 
 local function close_viewer()
@@ -94,7 +102,7 @@ local function pngify(filepath)
   if ext == "png" then
     return filepath, nil
   end
-  local temp_file = "/tmp/nvim_buddy_pngify.png"
+  local temp_file = vim.fn.tempname() .. ".png"
   local cmd
   if ext == "gif" then
     cmd = "magick " .. vim.fn.shellescape(filepath) .. "[0] " .. temp_file
@@ -110,7 +118,7 @@ local function pngify(filepath)
 end
 
 local function rescale(filepath, w, h, zoom, o_x, o_y)
-  local temp_file = "/tmp/nvim_buddy_scaled.png"
+  local temp_file = vim.fn.tempname() .. ".png"
   if vim.fn.filereadable(temp_file) == 1 then
     vim.fn.delete(temp_file)
   end
@@ -165,7 +173,9 @@ local function draw_image(x, y, w, h)
   local chunk_size = 4096
 
   -- Position cursor before drawing
-  stdout:write("\27[" .. (x + 2) .. ";" .. (y + 4) .. "H")
+  local out = get_stdout()
+  if not out then return end
+  out:write("\27[" .. (x + 2) .. ";" .. (y + 4) .. "H")
 
   while pos <= #encoded_data do
     local chunk = encoded_data:sub(pos, pos + chunk_size - 1)
@@ -174,12 +184,12 @@ local function draw_image(x, y, w, h)
 
     -- Use fixed image ID i=10 with a=T (transmit and display)
     local cmd = "\27_Ga=T,i=10,q=1,r=" .. h .. ",c=" .. w .. ",C=1,f=100,m=" .. m .. ";" .. chunk .. "\27\\"
-    stdout:write(cmd)
+    out:write(cmd)
     uv.sleep(1)
   end
 
   -- Reposition cursor
-  stdout:write("\27[" .. (x + 1) .. ";" .. (y + 3) .. "H")
+  out:write("\27[" .. (x + 1) .. ";" .. (y + 3) .. "H")
 end
 
 local function redraw()

--- a/tests/test_auth.lua
+++ b/tests/test_auth.lua
@@ -1,0 +1,149 @@
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    -- Fresh module state for each test
+    package.loaded['buddy.server.router'] = nil
+    package.loaded['buddy.config'] = nil
+  end
+}
+
+T['auth'] = MiniTest.new_set()
+
+-- Helper: create a mock http_server that captures send_response calls
+local function make_mock_server()
+  local mock = {
+    responses = {},
+    sse_connections = {},
+  }
+  function mock:send_response(client, status, headers, body)
+    table.insert(self.responses, {
+      status = status,
+      headers = headers,
+      body = body,
+    })
+  end
+  return mock
+end
+
+-- Helper: create a mock request with optional auth header
+local function make_request(method, path, auth_header)
+  local headers = {}
+  if auth_header then
+    headers["authorization"] = auth_header
+  end
+  return {
+    method = method,
+    path = path,
+    headers = headers,
+  }
+end
+
+T['auth']['rejects request without token when auth is enabled'] = function()
+  local router = require('buddy.server.router')
+  router.set_auth_token('test-secret-token')
+
+  local mock = make_mock_server()
+  local request = make_request('GET', '/sse', nil)
+
+  router.handle(mock, {}, request, '')
+
+  MiniTest.expect.equality(#mock.responses, 1)
+  MiniTest.expect.equality(mock.responses[1].status, 401)
+end
+
+T['auth']['rejects request with wrong token'] = function()
+  local router = require('buddy.server.router')
+  router.set_auth_token('correct-token')
+
+  local mock = make_mock_server()
+  local request = make_request('POST', '/message?sessionId=123', 'Bearer wrong-token')
+
+  router.handle(mock, {}, request, '')
+
+  MiniTest.expect.equality(#mock.responses, 1)
+  MiniTest.expect.equality(mock.responses[1].status, 401)
+end
+
+T['auth']['allows /health without token'] = function()
+  local router = require('buddy.server.router')
+  router.set_auth_token('secret-token')
+
+  local mock = make_mock_server()
+  local request = make_request('GET', '/health', nil)
+
+  router.handle(mock, {}, request, '')
+
+  -- /health should return 200, not 401
+  MiniTest.expect.equality(#mock.responses, 1)
+  MiniTest.expect.equality(mock.responses[1].status, 200)
+end
+
+T['auth']['allows request with correct token'] = function()
+  local router = require('buddy.server.router')
+  router.set_auth_token('my-secret')
+
+  local mock = make_mock_server()
+  -- Use /health with correct token to verify it passes auth AND completes
+  local request = make_request('GET', '/health', 'Bearer my-secret')
+
+  router.handle(mock, {}, request, '')
+
+  MiniTest.expect.equality(#mock.responses, 1)
+  MiniTest.expect.equality(mock.responses[1].status, 200)
+end
+
+T['auth']['allows all requests when auth is disabled (nil token)'] = function()
+  local router = require('buddy.server.router')
+  router.set_auth_token(nil)
+
+  local mock = make_mock_server()
+  -- /health without any auth header should work
+  local request = make_request('GET', '/health', nil)
+
+  router.handle(mock, {}, request, '')
+
+  MiniTest.expect.equality(#mock.responses, 1)
+  MiniTest.expect.equality(mock.responses[1].status, 200)
+end
+
+T['auth']['returns 401 for SSE endpoint without token'] = function()
+  local router = require('buddy.server.router')
+  router.set_auth_token('sse-token')
+
+  local mock = make_mock_server()
+  local request = make_request('GET', '/sse', nil)
+
+  router.handle(mock, {}, request, '')
+
+  MiniTest.expect.equality(#mock.responses, 1)
+  MiniTest.expect.equality(mock.responses[1].status, 401)
+end
+
+T['auth']['returns 401 for POST /message without token'] = function()
+  local router = require('buddy.server.router')
+  router.set_auth_token('msg-token')
+
+  local mock = make_mock_server()
+  local request = make_request('POST', '/message?sessionId=abc', nil)
+
+  router.handle(mock, {}, request, '')
+
+  MiniTest.expect.equality(#mock.responses, 1)
+  MiniTest.expect.equality(mock.responses[1].status, 401)
+end
+
+T['auth']['config defaults auth to true'] = function()
+  local config = require('buddy.config')
+  local cfg = config.get()
+  MiniTest.expect.equality(cfg.auth, true)
+end
+
+T['auth']['config auth can be disabled'] = function()
+  local config = require('buddy.config')
+  config.setup({ auth = false })
+  local cfg = config.get()
+  MiniTest.expect.equality(cfg.auth, false)
+end
+
+return T

--- a/tests/test_client_requester_service.lua
+++ b/tests/test_client_requester_service.lua
@@ -1,0 +1,246 @@
+-- Tests for services/client_requester.lua
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.services.client_requester'] = nil
+  end,
+}
+
+local function get_requester()
+  return require('buddy.services.client_requester')
+end
+
+T['ClientRequester'] = MiniTest.new_set()
+
+T['ClientRequester']['new() requires send_fn'] = function()
+  local ClientRequester = get_requester()
+  MiniTest.expect.error(function()
+    ClientRequester.new({})
+  end)
+  MiniTest.expect.error(function()
+    ClientRequester.new(nil)
+  end)
+end
+
+T['ClientRequester']['new() creates instance with send_fn'] = function()
+  local ClientRequester = get_requester()
+  local requester = ClientRequester.new({
+    send_fn = function() return true end,
+  })
+  MiniTest.expect.equality(type(requester), 'table')
+  MiniTest.expect.equality(type(requester.request_sync), 'function')
+  MiniTest.expect.equality(type(requester.handle_response), 'function')
+  MiniTest.expect.equality(type(requester.cleanup_session), 'function')
+end
+
+T['request/response'] = MiniTest.new_set()
+
+T['request/response']['request_sync sends correct JSON-RPC and returns on response'] = function()
+  local ClientRequester = get_requester()
+  local sent_messages = {}
+
+  local requester = ClientRequester.new({
+    send_fn = function(session_id, msg)
+      table.insert(sent_messages, { session_id = session_id, msg = msg })
+      -- Simulate async response arriving
+      vim.schedule(function()
+        requester:handle_response({
+          jsonrpc = '2.0',
+          id = msg.id,
+          result = { roots = { { uri = 'file:///test' } } },
+        })
+      end)
+      return true
+    end,
+  })
+
+  local result, err = requester:request_sync('session-1', 'roots/list', {}, 5000)
+
+  -- Verify message was sent
+  MiniTest.expect.equality(#sent_messages, 1)
+  MiniTest.expect.equality(sent_messages[1].session_id, 'session-1')
+  MiniTest.expect.equality(sent_messages[1].msg.jsonrpc, '2.0')
+  MiniTest.expect.equality(sent_messages[1].msg.method, 'roots/list')
+  MiniTest.expect.equality(type(sent_messages[1].msg.id), 'string')
+
+  -- Verify result
+  MiniTest.expect.equality(err, nil)
+  MiniTest.expect.equality(result.roots[1].uri, 'file:///test')
+end
+
+T['request/response']['request_sync returns error on send failure'] = function()
+  local ClientRequester = get_requester()
+
+  local requester = ClientRequester.new({
+    send_fn = function() return false end,
+  })
+
+  local result, err = requester:request_sync('session-1', 'roots/list', {}, 1000)
+
+  MiniTest.expect.equality(result, nil)
+  MiniTest.expect.equality(err, 'Failed to send request')
+end
+
+T['request/response']['request_sync returns error response from client'] = function()
+  local ClientRequester = get_requester()
+
+  local requester = ClientRequester.new({
+    send_fn = function(_session_id, msg)
+      vim.schedule(function()
+        requester:handle_response({
+          jsonrpc = '2.0',
+          id = msg.id,
+          error = { code = -32600, message = 'Invalid request' },
+        })
+      end)
+      return true
+    end,
+  })
+
+  local result, err = requester:request_sync('session-1', 'test/method', {}, 5000)
+
+  MiniTest.expect.equality(result, nil)
+  MiniTest.expect.equality(type(err), 'table')
+  MiniTest.expect.equality(err.code, -32600)
+  MiniTest.expect.equality(err.message, 'Invalid request')
+end
+
+T['request/response']['request_sync times out'] = function()
+  local ClientRequester = get_requester()
+
+  local requester = ClientRequester.new({
+    send_fn = function() return true end, -- Never responds
+  })
+
+  local result, err = requester:request_sync('session-1', 'test/method', {}, 100)
+
+  MiniTest.expect.equality(result, nil)
+  MiniTest.expect.equality(err, 'Request timeout')
+end
+
+T['request/response']['request IDs are unique'] = function()
+  local ClientRequester = get_requester()
+  local ids = {}
+
+  local requester = ClientRequester.new({
+    send_fn = function(_session_id, msg)
+      table.insert(ids, msg.id)
+      -- Respond immediately
+      vim.schedule(function()
+        requester:handle_response({
+          jsonrpc = '2.0',
+          id = msg.id,
+          result = {},
+        })
+      end)
+      return true
+    end,
+  })
+
+  requester:request_sync('s1', 'method1', {}, 1000)
+  requester:request_sync('s1', 'method2', {}, 1000)
+
+  MiniTest.expect.equality(#ids, 2)
+  -- IDs should be different
+  local different = ids[1] ~= ids[2]
+  MiniTest.expect.equality(different, true)
+end
+
+T['is_response'] = MiniTest.new_set()
+
+T['is_response']['returns true for pending request id'] = function()
+  local ClientRequester = get_requester()
+
+  local captured_id
+  local requester = ClientRequester.new({
+    send_fn = function(_session_id, msg)
+      captured_id = msg.id
+      return true
+    end,
+  })
+
+  -- Start a request but don't respond (will timeout)
+  vim.schedule(function()
+    requester:request_sync('s1', 'test', {}, 200)
+  end)
+  -- Give schedule a chance to fire
+  vim.wait(50, function() return captured_id ~= nil end, 5)
+
+  if captured_id then
+    local is_resp = requester:is_response({ id = captured_id })
+    MiniTest.expect.equality(is_resp, true)
+
+    local not_resp = requester:is_response({ id = 'nonexistent' })
+    MiniTest.expect.equality(not_resp, false)
+  end
+
+  -- Cleanup: wait for timeout
+  vim.wait(300, function() return false end, 10)
+end
+
+T['is_response']['returns false for unknown id'] = function()
+  local ClientRequester = get_requester()
+
+  local requester = ClientRequester.new({
+    send_fn = function() return true end,
+  })
+
+  MiniTest.expect.equality(requester:is_response({ id = 'unknown_123' }), false)
+  MiniTest.expect.equality(requester:is_response({}), false)
+end
+
+T['cleanup'] = MiniTest.new_set()
+
+T['cleanup']['cleanup_session rejects all pending requests for session'] = function()
+  local ClientRequester = get_requester()
+  local errors = {}
+
+  local requester = ClientRequester.new({
+    send_fn = function(_session_id, msg)
+      -- Start request but don't respond — we'll cleanup instead
+      vim.schedule(function()
+        -- After a short delay, cleanup the session
+        requester:cleanup_session('session-to-clean')
+      end)
+      return true
+    end,
+  })
+
+  local _result, err = requester:request_sync('session-to-clean', 'test/method', {}, 5000)
+
+  -- Should get session closed error
+  MiniTest.expect.equality(type(err), 'table')
+  MiniTest.expect.equality(err.message, 'Session closed')
+end
+
+T['cleanup']['cleanup_session does not affect other sessions'] = function()
+  local ClientRequester = get_requester()
+  local send_count = 0
+
+  local requester = ClientRequester.new({
+    send_fn = function(session_id, msg)
+      send_count = send_count + 1
+      if session_id == 'session-ok' then
+        vim.schedule(function()
+          requester:handle_response({
+            jsonrpc = '2.0',
+            id = msg.id,
+            result = { ok = true },
+          })
+        end)
+      end
+      return true
+    end,
+  })
+
+  -- Clean up session-bad (no pending requests for it yet, but that's fine)
+  requester:cleanup_session('session-bad')
+
+  -- session-ok should still work
+  local result, err = requester:request_sync('session-ok', 'test', {}, 5000)
+  MiniTest.expect.equality(err, nil)
+  MiniTest.expect.equality(result.ok, true)
+end
+
+return T

--- a/tests/test_executor.lua
+++ b/tests/test_executor.lua
@@ -1,0 +1,76 @@
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.tools'] = nil
+    package.loaded['buddy.tools.executor'] = nil
+  end
+}
+
+local function get_executor()
+  return require('buddy.tools.executor')
+end
+
+local function get_tools()
+  return require('buddy.tools')
+end
+
+T['execute()'] = MiniTest.new_set()
+
+T['execute()']['validates input_schema required fields'] = function()
+  -- Regression: P1 executor used tool.args but builtins use tool.input_schema
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'test-schema-tool',
+    description = 'Test tool with input_schema',
+    input_schema = {
+      type = "object",
+      properties = {
+        action = { type = "string", description = "Action" },
+      },
+      required = { "action" },
+    },
+    run = function(args)
+      return { success = true, action = args.action }
+    end,
+  })
+
+  -- Missing required field should throw
+  MiniTest.expect.error(function()
+    executor.execute('test-schema-tool', {})
+  end)
+
+  -- With required field should succeed
+  local result = executor.execute('test-schema-tool', { action = "test" })
+  MiniTest.expect.equality(result.success, true)
+end
+
+T['execute()']['validates legacy args schema'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'test-legacy-tool',
+    description = 'Test tool with legacy args',
+    args = {
+      name = { type = "string", description = "Name" },
+    },
+    required = { "name" },
+    run = function(args)
+      return { success = true, name = args.name }
+    end,
+  })
+
+  -- Missing required field should throw
+  MiniTest.expect.error(function()
+    executor.execute('test-legacy-tool', {})
+  end)
+
+  -- With required field should succeed
+  local result = executor.execute('test-legacy-tool', { name = "test" })
+  MiniTest.expect.equality(result.success, true)
+end
+
+return T

--- a/tests/test_log.lua
+++ b/tests/test_log.lua
@@ -1,0 +1,36 @@
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.log'] = nil
+  end
+}
+
+T['log'] = MiniTest.new_set()
+
+T['log']['does not crash on percent signs in message'] = function()
+  -- Regression: P1 logger crashed on stray % in format string
+  local log = require('buddy.log')
+
+  -- These should not throw
+  local ok1 = pcall(log.info, '100% complete')
+  MiniTest.expect.equality(ok1, true)
+
+  local ok2 = pcall(log.error, 'failed at 50%')
+  MiniTest.expect.equality(ok2, true)
+end
+
+T['log']['does not crash on mismatched format args'] = function()
+  -- Regression: P1 string.format with wrong arg count
+  local log = require('buddy.log')
+
+  -- Too few args for format specifiers
+  local ok1 = pcall(log.info, '%s and %s', 'one')
+  MiniTest.expect.equality(ok1, true)
+
+  -- Format specifier with no args
+  local ok2 = pcall(log.warning, '%d items processed')
+  MiniTest.expect.equality(ok2, true)
+end
+
+return T

--- a/tests/test_mcp_dispatcher.lua
+++ b/tests/test_mcp_dispatcher.lua
@@ -1,0 +1,182 @@
+-- Tests for protocol/mcp/dispatcher.lua
+local T = MiniTest.new_set()
+
+-- Fresh state for each test
+T['hooks'] = {
+  pre_case = function()
+    -- Clear cached modules for clean state
+    package.loaded['buddy.mcp'] = nil
+    package.loaded['buddy.mcp.methods'] = nil
+    package.loaded['buddy.protocol.mcp.dispatcher'] = nil
+    package.loaded['buddy.protocol.mcp.registry'] = nil
+    package.loaded['buddy.protocol.jsonrpc'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.core'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.tools'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.resources'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.prompts'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.completion'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.notifications'] = nil
+    package.loaded['buddy.tools'] = nil
+    package.loaded['buddy.tools.executor'] = nil
+  end,
+}
+
+local function get_dispatcher()
+  return require('buddy.protocol.mcp.dispatcher')
+end
+
+-- === JSON-RPC validation ===
+
+T['handle_request()'] = MiniTest.new_set()
+
+T['handle_request()']['rejects non-table request'] = function()
+  local dispatcher = get_dispatcher()
+  -- Non-table with an id can't produce a response (no id to reference)
+  local response = dispatcher.handle_request('s1', 'not a table')
+  MiniTest.expect.equality(response, nil)
+end
+
+T['handle_request()']['rejects missing jsonrpc version'] = function()
+  local dispatcher = get_dispatcher()
+  local response = dispatcher.handle_request('s1', { id = 1, method = 'ping' })
+  MiniTest.expect.equality(response.error.code, -32600)
+  MiniTest.expect.equality(response.id, 1)
+end
+
+T['handle_request()']['rejects missing method field'] = function()
+  local dispatcher = get_dispatcher()
+  local response = dispatcher.handle_request('s1', { jsonrpc = '2.0', id = 1 })
+  MiniTest.expect.equality(response.error.code, -32600)
+end
+
+T['handle_request()']['returns -32601 for unknown method'] = function()
+  local dispatcher = get_dispatcher()
+  local response = dispatcher.handle_request('s1', {
+    jsonrpc = '2.0',
+    id = 1,
+    method = 'nonexistent/method',
+  })
+  MiniTest.expect.equality(response.error.code, -32601)
+  MiniTest.expect.equality(response.id, 1)
+end
+
+T['handle_request()']['returns nil for unknown notification'] = function()
+  local dispatcher = get_dispatcher()
+  local response = dispatcher.handle_request('s1', {
+    jsonrpc = '2.0',
+    method = 'nonexistent/notification',
+  })
+  MiniTest.expect.equality(response, nil)
+end
+
+-- === Handler dispatch ===
+
+T['handle_request()']['dispatches ping and returns empty result'] = function()
+  local dispatcher = get_dispatcher()
+  local response = dispatcher.handle_request('s1', {
+    jsonrpc = '2.0',
+    id = 1,
+    method = 'ping',
+  })
+  MiniTest.expect.equality(response.jsonrpc, '2.0')
+  MiniTest.expect.equality(response.id, 1)
+  -- ping returns vim.empty_dict() which is a table
+  MiniTest.expect.equality(type(response.result), 'table')
+end
+
+T['handle_request()']['dispatches initialize with correct protocol version'] = function()
+  local dispatcher = get_dispatcher()
+  local response = dispatcher.handle_request('s1', {
+    jsonrpc = '2.0',
+    id = 1,
+    method = 'initialize',
+    params = {},
+  })
+  MiniTest.expect.equality(response.result.protocolVersion, '2025-06-18')
+  MiniTest.expect.equality(response.result.serverInfo.name, 'buddy')
+end
+
+T['handle_request()']['notifications/initialized returns nil'] = function()
+  local dispatcher = get_dispatcher()
+  local response = dispatcher.handle_request('s1', {
+    jsonrpc = '2.0',
+    method = 'notifications/initialized',
+    params = {},
+  })
+  MiniTest.expect.equality(response, nil)
+end
+
+T['handle_request()']['wraps handler errors in -32603'] = function()
+  local dispatcher = get_dispatcher()
+  -- tools/call with no params will error("Missing required parameter: name")
+  local response = dispatcher.handle_request('s1', {
+    jsonrpc = '2.0',
+    id = 5,
+    method = 'tools/call',
+    params = {},
+  })
+  MiniTest.expect.equality(response.error.code, -32603)
+  MiniTest.expect.equality(response.id, 5)
+end
+
+T['handle_request()']['notification handler error returns nil'] = function()
+  -- Register a handler that errors for testing
+  local registry = require('buddy.protocol.mcp.registry')
+  registry.register('notifications/test_error', function()
+    error('boom')
+  end)
+
+  local dispatcher = get_dispatcher()
+  local response = dispatcher.handle_request('s1', {
+    jsonrpc = '2.0',
+    method = 'notifications/test_error',
+  })
+  MiniTest.expect.equality(response, nil)
+end
+
+-- === Backward compatibility ===
+
+T['backward compatibility'] = MiniTest.new_set()
+
+T['backward compatibility']['mcp.handle_request delegates to dispatcher'] = function()
+  local mcp = require('buddy.mcp')
+  local response = mcp.handle_request('s1', {
+    jsonrpc = '2.0',
+    id = 1,
+    method = 'ping',
+  })
+  MiniTest.expect.equality(response.jsonrpc, '2.0')
+  MiniTest.expect.equality(response.id, 1)
+end
+
+T['backward compatibility']['methods facade supports index lookup'] = function()
+  local methods = require('buddy.mcp.methods')
+  local handler = methods['ping']
+  MiniTest.expect.equality(type(handler), 'function')
+end
+
+T['backward compatibility']['methods facade exposes content helpers'] = function()
+  local methods = require('buddy.mcp.methods')
+  MiniTest.expect.equality(type(methods.image_content), 'function')
+  MiniTest.expect.equality(type(methods.resource_content), 'function')
+  MiniTest.expect.equality(type(methods.embedded_resource), 'function')
+  MiniTest.expect.equality(type(methods.embedded_blob), 'function')
+  MiniTest.expect.equality(type(methods.resource_link), 'function')
+  MiniTest.expect.equality(type(methods.audio_content), 'function')
+end
+
+T['backward compatibility']['methods facade exposes notify functions'] = function()
+  local methods = require('buddy.mcp.methods')
+  MiniTest.expect.equality(type(methods.set_notify_callback), 'function')
+  MiniTest.expect.equality(type(methods.notify_tools_changed), 'function')
+  MiniTest.expect.equality(type(methods.notify_prompts_changed), 'function')
+  MiniTest.expect.equality(type(methods.notify_resources_changed), 'function')
+end
+
+T['backward compatibility']['methods.get_log_level works'] = function()
+  local methods = require('buddy.mcp.methods')
+  MiniTest.expect.equality(type(methods.get_log_level), 'function')
+  MiniTest.expect.equality(methods.get_log_level(), 'info')
+end
+
+return T

--- a/tests/test_mcp_handlers_resources.lua
+++ b/tests/test_mcp_handlers_resources.lua
@@ -1,0 +1,149 @@
+-- Tests for protocol/mcp/handlers/resources.lua
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.mcp'] = nil
+    package.loaded['buddy.mcp.methods'] = nil
+    package.loaded['buddy.protocol.mcp.dispatcher'] = nil
+    package.loaded['buddy.protocol.mcp.registry'] = nil
+    package.loaded['buddy.protocol.jsonrpc'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.core'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.tools'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.resources'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.prompts'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.completion'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.notifications'] = nil
+    package.loaded['buddy.tools'] = nil
+    package.loaded['buddy.tools.executor'] = nil
+    package.loaded['buddy.resources'] = nil
+  end,
+}
+
+local function mcp_request(session_id, id, method, params)
+  local dispatcher = require('buddy.protocol.mcp.dispatcher')
+  return dispatcher.handle_request(session_id, {
+    jsonrpc = '2.0',
+    id = id,
+    method = method,
+    params = params or {},
+  })
+end
+
+T['resources/list'] = MiniTest.new_set()
+
+T['resources/list']['returns resource list'] = function()
+  local response = mcp_request('s1', 1, 'resources/list')
+  MiniTest.expect.equality(response.id, 1)
+  MiniTest.expect.equality(type(response.result.resources), 'table')
+end
+
+T['resources/read'] = MiniTest.new_set()
+
+T['resources/read']['errors on missing uri'] = function()
+  local response = mcp_request('s1', 2, 'resources/read', {})
+  MiniTest.expect.equality(response.error.code, -32603)
+end
+
+T['resources/subscribe'] = MiniTest.new_set()
+
+T['resources/subscribe']['errors on missing uri'] = function()
+  local response = mcp_request('s1', 3, 'resources/subscribe', {})
+  MiniTest.expect.equality(response.error.code, -32603)
+end
+
+T['resources/subscribe']['succeeds with valid uri'] = function()
+  local response = mcp_request('s1', 4, 'resources/subscribe', { uri = 'vim://buffer/1' })
+  MiniTest.expect.equality(response.id, 4)
+  -- Result is vim.empty_dict() — a table
+  MiniTest.expect.equality(type(response.result), 'table')
+end
+
+T['resources/unsubscribe'] = MiniTest.new_set()
+
+T['resources/unsubscribe']['errors on missing uri'] = function()
+  local response = mcp_request('s1', 5, 'resources/unsubscribe', {})
+  MiniTest.expect.equality(response.error.code, -32603)
+end
+
+T['resources/unsubscribe']['succeeds with valid uri'] = function()
+  local response = mcp_request('s1', 6, 'resources/unsubscribe', { uri = 'vim://buffer/1' })
+  MiniTest.expect.equality(response.id, 6)
+  MiniTest.expect.equality(type(response.result), 'table')
+end
+
+T['resources/subscribe']['subscribe then unsubscribe roundtrip'] = function()
+  local sub_response = mcp_request('s1', 7, 'resources/subscribe', { uri = 'vim://buffer/1' })
+  MiniTest.expect.equality(sub_response.id, 7)
+
+  local unsub_response = mcp_request('s1', 8, 'resources/unsubscribe', { uri = 'vim://buffer/1' })
+  MiniTest.expect.equality(unsub_response.id, 8)
+end
+
+-- === Content helpers ===
+
+T['content helpers'] = MiniTest.new_set()
+
+T['content helpers']['image_content constructs correctly'] = function()
+  local content = require('buddy.protocol.mcp.content')
+  local result = content.image_content('abc123', 'image/jpeg')
+  MiniTest.expect.equality(result.type, 'image')
+  MiniTest.expect.equality(result.data, 'abc123')
+  MiniTest.expect.equality(result.mimeType, 'image/jpeg')
+end
+
+T['content helpers']['image_content defaults to png'] = function()
+  local content = require('buddy.protocol.mcp.content')
+  local result = content.image_content('abc123')
+  MiniTest.expect.equality(result.mimeType, 'image/png')
+end
+
+T['content helpers']['resource_content constructs correctly'] = function()
+  local content = require('buddy.protocol.mcp.content')
+  local result = content.resource_content('vim://buffer/1', 'text/lua', 'print("hi")')
+  MiniTest.expect.equality(result.type, 'resource')
+  MiniTest.expect.equality(result.resource.uri, 'vim://buffer/1')
+  MiniTest.expect.equality(result.resource.mimeType, 'text/lua')
+  MiniTest.expect.equality(result.resource.text, 'print("hi")')
+end
+
+T['content helpers']['embedded_resource constructs correctly'] = function()
+  local content = require('buddy.protocol.mcp.content')
+  local result = content.embedded_resource('vim://buffer/1', 'hello', 'text/plain')
+  MiniTest.expect.equality(result.type, 'resource')
+  MiniTest.expect.equality(result.resource.text, 'hello')
+end
+
+T['content helpers']['embedded_blob constructs correctly'] = function()
+  local content = require('buddy.protocol.mcp.content')
+  local result = content.embedded_blob('vim://file/x.png', 'base64data', 'image/png')
+  MiniTest.expect.equality(result.resource.blob, 'base64data')
+  MiniTest.expect.equality(result.resource.mimeType, 'image/png')
+end
+
+T['content helpers']['resource_link requires name'] = function()
+  local content = require('buddy.protocol.mcp.content')
+  MiniTest.expect.error(function()
+    content.resource_link('vim://buffer/1', '')
+  end)
+end
+
+T['content helpers']['resource_link constructs correctly'] = function()
+  local content = require('buddy.protocol.mcp.content')
+  local result = content.resource_link('vim://buffer/1', 'Buffer 1', 'A buffer', 'text/plain')
+  MiniTest.expect.equality(result.type, 'resource_link')
+  MiniTest.expect.equality(result.uri, 'vim://buffer/1')
+  MiniTest.expect.equality(result.name, 'Buffer 1')
+  MiniTest.expect.equality(result.description, 'A buffer')
+  MiniTest.expect.equality(result.mimeType, 'text/plain')
+end
+
+T['content helpers']['audio_content constructs correctly'] = function()
+  local content = require('buddy.protocol.mcp.content')
+  local result = content.audio_content('audiodata', 'audio/wav')
+  MiniTest.expect.equality(result.type, 'audio')
+  MiniTest.expect.equality(result.data, 'audiodata')
+  MiniTest.expect.equality(result.mimeType, 'audio/wav')
+end
+
+return T

--- a/tests/test_mcp_handlers_tools.lua
+++ b/tests/test_mcp_handlers_tools.lua
@@ -1,0 +1,173 @@
+-- Tests for protocol/mcp/handlers/tools.lua
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.mcp'] = nil
+    package.loaded['buddy.mcp.methods'] = nil
+    package.loaded['buddy.protocol.mcp.dispatcher'] = nil
+    package.loaded['buddy.protocol.mcp.registry'] = nil
+    package.loaded['buddy.protocol.jsonrpc'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.core'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.tools'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.resources'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.prompts'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.completion'] = nil
+    package.loaded['buddy.protocol.mcp.handlers.notifications'] = nil
+    package.loaded['buddy.tools'] = nil
+    package.loaded['buddy.tools.executor'] = nil
+  end,
+}
+
+local function mcp_request(session_id, id, method, params)
+  local dispatcher = require('buddy.protocol.mcp.dispatcher')
+  return dispatcher.handle_request(session_id, {
+    jsonrpc = '2.0',
+    id = id,
+    method = method,
+    params = params or {},
+  })
+end
+
+T['tools/list'] = MiniTest.new_set()
+
+T['tools/list']['returns registered tools'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+  tools.register({
+    name = 'test-tool',
+    description = 'A test tool',
+    input_schema = { type = 'object' },
+    run = function() return 'ok' end,
+  })
+
+  local response = mcp_request('s1', 1, 'tools/list')
+  MiniTest.expect.equality(response.id, 1)
+  MiniTest.expect.equality(#response.result.tools, 1)
+  MiniTest.expect.equality(response.result.tools[1].name, 'test-tool')
+  MiniTest.expect.equality(response.result.tools[1].description, 'A test tool')
+end
+
+T['tools/list']['returns empty list when no tools registered'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+
+  local response = mcp_request('s1', 1, 'tools/list')
+  MiniTest.expect.equality(#response.result.tools, 0)
+end
+
+T['tools/list']['provides default inputSchema when tool has none'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+  tools.register({
+    name = 'no-schema',
+    description = 'No schema',
+    run = function() return 'ok' end,
+  })
+
+  local response = mcp_request('s1', 1, 'tools/list')
+  local schema = response.result.tools[1].inputSchema
+  MiniTest.expect.equality(schema.type, 'object')
+  -- properties should serialize as object not array
+  local json = vim.json.encode(schema)
+  MiniTest.expect.equality(json:sub(1, 1), '{')
+end
+
+T['tools/list']['preserves explicit inputSchema'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+  tools.register({
+    name = 'with-schema',
+    description = 'Has schema',
+    input_schema = {
+      type = 'object',
+      properties = { name = { type = 'string' } },
+      required = { 'name' },
+    },
+    run = function() return 'ok' end,
+  })
+
+  local response = mcp_request('s1', 1, 'tools/list')
+  local schema = response.result.tools[1].inputSchema
+  MiniTest.expect.equality(schema.properties.name.type, 'string')
+  MiniTest.expect.equality(schema.required[1], 'name')
+end
+
+T['tools/list']['includes optional fields when present'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+  tools.register({
+    name = 'full-tool',
+    description = 'Full tool',
+    title = 'Full Tool Title',
+    annotations = { readOnly = true },
+    output_schema = { type = 'object' },
+    run = function() return {} end,
+  })
+
+  local response = mcp_request('s1', 1, 'tools/list')
+  local tool = response.result.tools[1]
+  MiniTest.expect.equality(tool.title, 'Full Tool Title')
+  MiniTest.expect.equality(tool.annotations.readOnly, true)
+  MiniTest.expect.equality(tool.outputSchema.type, 'object')
+end
+
+T['tools/call'] = MiniTest.new_set()
+
+T['tools/call']['executes tool and returns text content'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+  tools.register({
+    name = 'echo',
+    description = 'Returns input',
+    run = function(args) return 'Hello ' .. (args.name or 'world') end,
+  })
+
+  local response = mcp_request('s1', 2, 'tools/call', { name = 'echo', arguments = { name = 'Claude' } })
+  MiniTest.expect.equality(response.id, 2)
+  MiniTest.expect.equality(response.result.content[1].type, 'text')
+  MiniTest.expect.equality(response.result.content[1].text, 'Hello Claude')
+end
+
+T['tools/call']['errors on missing tool name'] = function()
+  local response = mcp_request('s1', 3, 'tools/call', {})
+  MiniTest.expect.equality(response.error.code, -32603)
+end
+
+T['tools/call']['errors on unknown tool'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+  local response = mcp_request('s1', 4, 'tools/call', { name = 'nonexistent' })
+  MiniTest.expect.equality(response.error.code, -32603)
+end
+
+T['tools/call']['returns JSON-encoded table results'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+  tools.register({
+    name = 'json-tool',
+    description = 'Returns table',
+    run = function() return { key = 'value' } end,
+  })
+
+  local response = mcp_request('s1', 5, 'tools/call', { name = 'json-tool' })
+  local text = response.result.content[1].text
+  local decoded = vim.json.decode(text)
+  MiniTest.expect.equality(decoded.key, 'value')
+end
+
+T['tools/call']['includes structuredContent for tools with output_schema'] = function()
+  local tools = require('buddy.tools')
+  tools.clear()
+  tools.register({
+    name = 'structured',
+    description = 'Structured output',
+    output_schema = { type = 'object' },
+    run = function() return { data = 'test' } end,
+  })
+
+  local response = mcp_request('s1', 6, 'tools/call', { name = 'structured' })
+  MiniTest.expect.equality(response.result.structuredContent.data, 'test')
+end
+
+return T

--- a/tests/test_notifier.lua
+++ b/tests/test_notifier.lua
@@ -1,0 +1,210 @@
+-- Tests for services/notifier.lua
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.services.notifier'] = nil
+  end,
+}
+
+local function get_notifier()
+  return require('buddy.services.notifier')
+end
+
+T['Notifier'] = MiniTest.new_set()
+
+T['Notifier']['new() requires send_fn'] = function()
+  local Notifier = get_notifier()
+  MiniTest.expect.error(function()
+    Notifier.new({})
+  end)
+  MiniTest.expect.error(function()
+    Notifier.new(nil)
+  end)
+end
+
+T['Notifier']['new() creates instance with send_fn'] = function()
+  local Notifier = get_notifier()
+  local notifier = Notifier.new({
+    send_fn = function() return true end,
+  })
+  MiniTest.expect.equality(type(notifier), 'table')
+  MiniTest.expect.equality(type(notifier.notify), 'function')
+  MiniTest.expect.equality(type(notifier.broadcast), 'function')
+end
+
+T['notify()'] = MiniTest.new_set()
+
+T['notify()']['sends correct JSON-RPC notification'] = function()
+  local Notifier = get_notifier()
+  local sent = {}
+
+  local notifier = Notifier.new({
+    send_fn = function(session_id, msg)
+      table.insert(sent, { session_id = session_id, msg = msg })
+      return true
+    end,
+  })
+
+  local ok = notifier:notify('session-1', 'notifications/tools/list_changed')
+
+  MiniTest.expect.equality(ok, true)
+  MiniTest.expect.equality(#sent, 1)
+  MiniTest.expect.equality(sent[1].session_id, 'session-1')
+  MiniTest.expect.equality(sent[1].msg.jsonrpc, '2.0')
+  MiniTest.expect.equality(sent[1].msg.method, 'notifications/tools/list_changed')
+  MiniTest.expect.equality(sent[1].msg.params, nil)
+end
+
+T['notify()']['includes params when provided'] = function()
+  local Notifier = get_notifier()
+  local sent = {}
+
+  local notifier = Notifier.new({
+    send_fn = function(session_id, msg)
+      table.insert(sent, { session_id = session_id, msg = msg })
+      return true
+    end,
+  })
+
+  notifier:notify('session-1', 'notifications/resources/updated', { uri = 'file:///test' })
+
+  MiniTest.expect.equality(#sent, 1)
+  MiniTest.expect.equality(sent[1].msg.params.uri, 'file:///test')
+end
+
+T['notify()']['returns false when send fails'] = function()
+  local Notifier = get_notifier()
+
+  local notifier = Notifier.new({
+    send_fn = function() return false end,
+  })
+
+  local ok = notifier:notify('session-1', 'test/method')
+  MiniTest.expect.equality(ok, false)
+end
+
+T['notify()']['notification has no id field'] = function()
+  local Notifier = get_notifier()
+  local sent = {}
+
+  local notifier = Notifier.new({
+    send_fn = function(_session_id, msg)
+      table.insert(sent, msg)
+      return true
+    end,
+  })
+
+  notifier:notify('s1', 'notifications/tools/list_changed')
+
+  MiniTest.expect.equality(sent[1].id, nil)
+end
+
+T['broadcast()'] = MiniTest.new_set()
+
+T['broadcast()']['sends to all specified sessions'] = function()
+  local Notifier = get_notifier()
+  local sent = {}
+
+  local notifier = Notifier.new({
+    send_fn = function(session_id, msg)
+      table.insert(sent, { session_id = session_id, msg = msg })
+      return true
+    end,
+  })
+
+  notifier:broadcast('notifications/tools/list_changed', nil, { 's1', 's2', 's3' })
+
+  MiniTest.expect.equality(#sent, 3)
+  MiniTest.expect.equality(sent[1].session_id, 's1')
+  MiniTest.expect.equality(sent[2].session_id, 's2')
+  MiniTest.expect.equality(sent[3].session_id, 's3')
+end
+
+T['broadcast()']['includes params in broadcast'] = function()
+  local Notifier = get_notifier()
+  local sent = {}
+
+  local notifier = Notifier.new({
+    send_fn = function(session_id, msg)
+      table.insert(sent, msg)
+      return true
+    end,
+  })
+
+  notifier:broadcast('notifications/progress', { progress = 50 }, { 's1' })
+
+  MiniTest.expect.equality(#sent, 1)
+  MiniTest.expect.equality(sent[1].params.progress, 50)
+end
+
+T['broadcast()']['broadcasts to all via broadcast_fn when session_ids is nil'] = function()
+  local Notifier = get_notifier()
+  local broadcasted = {}
+
+  local notifier = Notifier.new({
+    send_fn = function() return true end,
+    broadcast_fn = function(msg)
+      table.insert(broadcasted, msg)
+    end,
+  })
+
+  notifier:broadcast('notifications/tools/list_changed', { test = true }, nil)
+
+  MiniTest.expect.equality(#broadcasted, 1)
+  MiniTest.expect.equality(broadcasted[1].jsonrpc, '2.0')
+  MiniTest.expect.equality(broadcasted[1].method, 'notifications/tools/list_changed')
+  MiniTest.expect.equality(broadcasted[1].params.test, true)
+end
+
+T['broadcast()']['does nothing when session_ids is nil and no broadcast_fn'] = function()
+  local Notifier = get_notifier()
+  local call_count = 0
+
+  local notifier = Notifier.new({
+    send_fn = function()
+      call_count = call_count + 1
+      return true
+    end,
+  })
+
+  notifier:broadcast('test/method', nil, nil)
+
+  MiniTest.expect.equality(call_count, 0)
+end
+
+T['broadcast()']['does nothing when session_ids is empty'] = function()
+  local Notifier = get_notifier()
+  local call_count = 0
+
+  local notifier = Notifier.new({
+    send_fn = function()
+      call_count = call_count + 1
+      return true
+    end,
+  })
+
+  notifier:broadcast('test/method', nil, {})
+
+  MiniTest.expect.equality(call_count, 0)
+end
+
+T['broadcast()']['continues even when some sends fail'] = function()
+  local Notifier = get_notifier()
+  local sent = {}
+
+  local notifier = Notifier.new({
+    send_fn = function(session_id, msg)
+      table.insert(sent, session_id)
+      -- s2 fails
+      return session_id ~= 's2'
+    end,
+  })
+
+  notifier:broadcast('test/method', nil, { 's1', 's2', 's3' })
+
+  -- All 3 should have been attempted
+  MiniTest.expect.equality(#sent, 3)
+end
+
+return T

--- a/tests/test_runtime_event_bus.lua
+++ b/tests/test_runtime_event_bus.lua
@@ -1,0 +1,134 @@
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.runtime.event_bus'] = nil
+  end,
+}
+
+local function new_bus()
+  return require('buddy.runtime.event_bus').new()
+end
+
+T['EventBus'] = MiniTest.new_set()
+
+T['EventBus']['new() creates independent instances'] = function()
+  local bus1 = new_bus()
+  local bus2 = new_bus()
+  local count = 0
+  bus1:subscribe('evt', function() count = count + 1 end)
+  bus2:publish('evt', {})
+  MiniTest.expect.equality(count, 0)
+  bus1:publish('evt', {})
+  MiniTest.expect.equality(count, 1)
+end
+
+T['EventBus']['subscribe and publish'] = function()
+  local bus = new_bus()
+  local received = nil
+  bus:subscribe('test_event', function(payload)
+    received = payload
+  end)
+  bus:publish('test_event', { key = 'value' })
+  MiniTest.expect.equality(received.key, 'value')
+end
+
+T['EventBus']['publish with no subscribers does not error'] = function()
+  local bus = new_bus()
+  -- Should not throw
+  bus:publish('nonexistent_event', { data = 1 })
+  bus:publish('another_event')
+end
+
+T['EventBus']['unsubscribe removes listener'] = function()
+  local bus = new_bus()
+  local count = 0
+  local unsub = bus:subscribe('evt', function()
+    count = count + 1
+  end)
+  bus:publish('evt')
+  MiniTest.expect.equality(count, 1)
+  unsub()
+  bus:publish('evt')
+  MiniTest.expect.equality(count, 1)
+end
+
+T['EventBus']['multiple subscribers all receive events'] = function()
+  local bus = new_bus()
+  local results = {}
+  bus:subscribe('multi', function(p) results[#results + 1] = 'a:' .. p.v end)
+  bus:subscribe('multi', function(p) results[#results + 1] = 'b:' .. p.v end)
+  bus:subscribe('multi', function(p) results[#results + 1] = 'c:' .. p.v end)
+  bus:publish('multi', { v = '1' })
+  MiniTest.expect.equality(#results, 3)
+  MiniTest.expect.equality(results[1], 'a:1')
+  MiniTest.expect.equality(results[2], 'b:1')
+  MiniTest.expect.equality(results[3], 'c:1')
+end
+
+T['EventBus']['unsubscribe one does not affect others'] = function()
+  local bus = new_bus()
+  local a_count, b_count = 0, 0
+  local unsub_a = bus:subscribe('evt', function() a_count = a_count + 1 end)
+  bus:subscribe('evt', function() b_count = b_count + 1 end)
+
+  bus:publish('evt')
+  MiniTest.expect.equality(a_count, 1)
+  MiniTest.expect.equality(b_count, 1)
+
+  unsub_a()
+  bus:publish('evt')
+  MiniTest.expect.equality(a_count, 1)
+  MiniTest.expect.equality(b_count, 2)
+end
+
+T['EventBus']['subscriber error does not prevent other subscribers'] = function()
+  local bus = new_bus()
+  local received = false
+  bus:subscribe('err_event', function()
+    error('boom')
+  end)
+  bus:subscribe('err_event', function()
+    received = true
+  end)
+  bus:publish('err_event')
+  MiniTest.expect.equality(received, true)
+end
+
+T['EventBus']['publish with nil payload'] = function()
+  local bus = new_bus()
+  local called = false
+  local received_payload = 'sentinel'
+  bus:subscribe('nil_evt', function(payload)
+    called = true
+    received_payload = payload
+  end)
+  bus:publish('nil_evt')
+  MiniTest.expect.equality(called, true)
+  MiniTest.expect.equality(received_payload, nil)
+end
+
+T['EventBus']['different events are independent'] = function()
+  local bus = new_bus()
+  local a_count, b_count = 0, 0
+  bus:subscribe('event_a', function() a_count = a_count + 1 end)
+  bus:subscribe('event_b', function() b_count = b_count + 1 end)
+  bus:publish('event_a')
+  MiniTest.expect.equality(a_count, 1)
+  MiniTest.expect.equality(b_count, 0)
+  bus:publish('event_b')
+  MiniTest.expect.equality(a_count, 1)
+  MiniTest.expect.equality(b_count, 1)
+end
+
+T['EventBus']['double unsubscribe is safe'] = function()
+  local bus = new_bus()
+  local count = 0
+  local unsub = bus:subscribe('evt', function() count = count + 1 end)
+  unsub()
+  unsub() -- should not error
+  bus:publish('evt')
+  MiniTest.expect.equality(count, 0)
+end
+
+return T

--- a/tests/test_runtime_request_store.lua
+++ b/tests/test_runtime_request_store.lua
@@ -1,0 +1,159 @@
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.runtime.state.request_store'] = nil
+  end,
+}
+
+local function new_store()
+  return require('buddy.runtime.state.request_store').new()
+end
+
+T['RequestStore'] = MiniTest.new_set()
+
+T['RequestStore']['new() creates independent instances'] = function()
+  local r1 = new_store()
+  local r2 = new_store()
+  r1:start('req1', { session_id = 's1', method = 'test' })
+  MiniTest.expect.equality(r2:get('req1'), nil)
+end
+
+T['RequestStore']['start and get'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1', method = 'tools/call' })
+  local entry = store:get('req1')
+  MiniTest.expect.no_equality(entry, nil)
+  MiniTest.expect.equality(entry.key, 'req1')
+  MiniTest.expect.equality(entry.session_id, 's1')
+  MiniTest.expect.equality(entry.status, 'pending')
+  MiniTest.expect.equality(entry.meta.method, 'tools/call')
+  MiniTest.expect.equality(entry.result, nil)
+  MiniTest.expect.equality(entry.error, nil)
+end
+
+T['RequestStore']['get returns nil for unknown key'] = function()
+  local store = new_store()
+  MiniTest.expect.equality(store:get('nonexistent'), nil)
+end
+
+T['RequestStore']['resolve pending request'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1' })
+  local ok = store:resolve('req1', { content = 'hello' })
+  MiniTest.expect.equality(ok, true)
+  local entry = store:get('req1')
+  MiniTest.expect.equality(entry.status, 'resolved')
+  MiniTest.expect.equality(entry.result.content, 'hello')
+end
+
+T['RequestStore']['resolve non-pending returns false'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1' })
+  store:resolve('req1', 'first')
+  local ok = store:resolve('req1', 'second')
+  MiniTest.expect.equality(ok, false)
+end
+
+T['RequestStore']['resolve unknown key returns false'] = function()
+  local store = new_store()
+  local ok = store:resolve('ghost', 'data')
+  MiniTest.expect.equality(ok, false)
+end
+
+T['RequestStore']['reject pending request'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1' })
+  local ok = store:reject('req1', 'timeout')
+  MiniTest.expect.equality(ok, true)
+  local entry = store:get('req1')
+  MiniTest.expect.equality(entry.status, 'rejected')
+  MiniTest.expect.equality(entry.error, 'timeout')
+end
+
+T['RequestStore']['reject non-pending returns false'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1' })
+  store:reject('req1', 'err1')
+  local ok = store:reject('req1', 'err2')
+  MiniTest.expect.equality(ok, false)
+end
+
+T['RequestStore']['reject unknown key returns false'] = function()
+  local store = new_store()
+  local ok = store:reject('ghost', 'err')
+  MiniTest.expect.equality(ok, false)
+end
+
+T['RequestStore']['cannot resolve after reject'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1' })
+  store:reject('req1', 'err')
+  local ok = store:resolve('req1', 'data')
+  MiniTest.expect.equality(ok, false)
+  MiniTest.expect.equality(store:get('req1').status, 'rejected')
+end
+
+T['RequestStore']['cannot reject after resolve'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1' })
+  store:resolve('req1', 'data')
+  local ok = store:reject('req1', 'err')
+  MiniTest.expect.equality(ok, false)
+  MiniTest.expect.equality(store:get('req1').status, 'resolved')
+end
+
+-- ── cleanup_by_session ─────────────────────────────────────────────────
+
+T['RequestStore']['cleanup_by_session removes all session requests'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1', method = 'a' })
+  store:start('req2', { session_id = 's1', method = 'b' })
+  store:start('req3', { session_id = 's2', method = 'c' })
+
+  store:cleanup_by_session('s1')
+
+  MiniTest.expect.equality(store:get('req1'), nil)
+  MiniTest.expect.equality(store:get('req2'), nil)
+  MiniTest.expect.no_equality(store:get('req3'), nil)
+end
+
+T['RequestStore']['cleanup_by_session rejects pending before removal'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1' })
+  store:start('req2', { session_id = 's1' })
+  store:resolve('req2', 'done')
+
+  -- We can't check the status after cleanup since entries are removed,
+  -- but we can verify the resolve on req2 was already done
+  store:cleanup_by_session('s1')
+  MiniTest.expect.equality(store:get('req1'), nil)
+  MiniTest.expect.equality(store:get('req2'), nil)
+end
+
+T['RequestStore']['cleanup_by_session with no matching requests is safe'] = function()
+  local store = new_store()
+  store:start('req1', { session_id = 's1' })
+  -- Should not throw
+  store:cleanup_by_session('s999')
+  -- Original request untouched
+  MiniTest.expect.no_equality(store:get('req1'), nil)
+end
+
+T['RequestStore']['cleanup_by_session with empty store is safe'] = function()
+  local store = new_store()
+  -- Should not throw
+  store:cleanup_by_session('s1')
+end
+
+T['RequestStore']['start records started_at timestamp'] = function()
+  local store = new_store()
+  local before = vim.uv.hrtime()
+  store:start('req1', { session_id = 's1' })
+  local after = vim.uv.hrtime()
+  local entry = store:get('req1')
+  MiniTest.expect.equality(entry.started_at >= before, true)
+  MiniTest.expect.equality(entry.started_at <= after, true)
+end
+
+return T

--- a/tests/test_runtime_session_store.lua
+++ b/tests/test_runtime_session_store.lua
@@ -1,0 +1,160 @@
+local T = MiniTest.new_set()
+
+T['hooks'] = {
+  pre_case = function()
+    package.loaded['buddy.runtime.state.session_store'] = nil
+  end,
+}
+
+local function new_store()
+  return require('buddy.runtime.state.session_store').new()
+end
+
+T['SessionStore'] = MiniTest.new_set()
+
+T['SessionStore']['new() creates independent instances'] = function()
+  local s1 = new_store()
+  local s2 = new_store()
+  s1:init_session('sess1', { capabilities = { sampling = {} } })
+  MiniTest.expect.equality(s2:get('sess1'), nil)
+end
+
+T['SessionStore']['init_session and get'] = function()
+  local store = new_store()
+  store:init_session('s1', {
+    capabilities = { sampling = {} },
+    clientInfo = { name = 'test-client', version = '1.0' },
+  })
+  local session = store:get('s1')
+  MiniTest.expect.no_equality(session, nil)
+  MiniTest.expect.equality(session.session_id, 's1')
+  MiniTest.expect.equality(session.capabilities.sampling ~= nil, true)
+  MiniTest.expect.equality(session.client_info.name, 'test-client')
+end
+
+T['SessionStore']['get returns nil for unknown session'] = function()
+  local store = new_store()
+  MiniTest.expect.equality(store:get('nonexistent'), nil)
+end
+
+T['SessionStore']['init_session with empty params'] = function()
+  local store = new_store()
+  store:init_session('s1', {})
+  local session = store:get('s1')
+  MiniTest.expect.no_equality(session, nil)
+  MiniTest.expect.equality(vim.tbl_count(session.capabilities), 0)
+  MiniTest.expect.equality(vim.tbl_count(session.client_info), 0)
+end
+
+T['SessionStore']['update merges patch'] = function()
+  local store = new_store()
+  store:init_session('s1', { capabilities = { roots = {} } })
+  store:update('s1', { cached_roots = { '/home/user' } })
+  local session = store:get('s1')
+  MiniTest.expect.equality(session.cached_roots[1], '/home/user')
+  -- Original fields preserved
+  MiniTest.expect.equality(session.capabilities.roots ~= nil, true)
+end
+
+T['SessionStore']['update on nonexistent session is no-op'] = function()
+  local store = new_store()
+  -- Should not throw
+  store:update('nonexistent', { key = 'value' })
+  MiniTest.expect.equality(store:get('nonexistent'), nil)
+end
+
+T['SessionStore']['cleanup removes session'] = function()
+  local store = new_store()
+  store:init_session('s1', { capabilities = {} })
+  MiniTest.expect.no_equality(store:get('s1'), nil)
+  store:cleanup('s1')
+  MiniTest.expect.equality(store:get('s1'), nil)
+end
+
+T['SessionStore']['cleanup on nonexistent session is safe'] = function()
+  local store = new_store()
+  -- Should not throw
+  store:cleanup('nonexistent')
+end
+
+T['SessionStore']['full lifecycle'] = function()
+  local store = new_store()
+  -- Init
+  store:init_session('lifecycle', { capabilities = { sampling = {} }, clientInfo = { name = 'c' } })
+  MiniTest.expect.no_equality(store:get('lifecycle'), nil)
+
+  -- Update
+  store:update('lifecycle', { cached_roots = { '/tmp' } })
+  MiniTest.expect.equality(store:get('lifecycle').cached_roots[1], '/tmp')
+
+  -- Add subscriptions
+  store:add_subscription('lifecycle', 'file:///a.txt')
+  store:add_subscription('lifecycle', 'file:///b.txt')
+
+  -- Cleanup
+  store:cleanup('lifecycle')
+  MiniTest.expect.equality(store:get('lifecycle'), nil)
+end
+
+-- ── Subscriptions ──────────────────────────────────────────────────────
+
+T['SessionStore']['add_subscription and remove_subscription'] = function()
+  local store = new_store()
+  store:init_session('s1', {})
+  store:add_subscription('s1', 'file:///test.txt')
+  local session = store:get('s1')
+  MiniTest.expect.equality(session.subscriptions['file:///test.txt'], true)
+
+  store:remove_subscription('s1', 'file:///test.txt')
+  session = store:get('s1')
+  MiniTest.expect.equality(session.subscriptions['file:///test.txt'], nil)
+end
+
+T['SessionStore']['add_subscription on nonexistent session is no-op'] = function()
+  local store = new_store()
+  store:add_subscription('ghost', 'file:///x')
+  MiniTest.expect.equality(store:get('ghost'), nil)
+end
+
+T['SessionStore']['remove_subscription on nonexistent session is no-op'] = function()
+  local store = new_store()
+  store:remove_subscription('ghost', 'file:///x')
+end
+
+T['SessionStore']['subscribers_for_uri'] = function()
+  local store = new_store()
+  store:init_session('s1', {})
+  store:init_session('s2', {})
+  store:init_session('s3', {})
+
+  store:add_subscription('s1', 'file:///shared.txt')
+  store:add_subscription('s2', 'file:///shared.txt')
+  store:add_subscription('s3', 'file:///other.txt')
+
+  local subs = store:subscribers_for_uri('file:///shared.txt')
+  table.sort(subs)
+  MiniTest.expect.equality(#subs, 2)
+  MiniTest.expect.equality(subs[1], 's1')
+  MiniTest.expect.equality(subs[2], 's2')
+end
+
+T['SessionStore']['subscribers_for_uri with no subscribers'] = function()
+  local store = new_store()
+  local subs = store:subscribers_for_uri('file:///nothing')
+  MiniTest.expect.equality(#subs, 0)
+end
+
+T['SessionStore']['subscribers_for_uri updates after cleanup'] = function()
+  local store = new_store()
+  store:init_session('s1', {})
+  store:init_session('s2', {})
+  store:add_subscription('s1', 'file:///doc.txt')
+  store:add_subscription('s2', 'file:///doc.txt')
+
+  store:cleanup('s1')
+  local subs = store:subscribers_for_uri('file:///doc.txt')
+  MiniTest.expect.equality(#subs, 1)
+  MiniTest.expect.equality(subs[1], 's2')
+end
+
+return T

--- a/tests/test_tool_edit.lua
+++ b/tests/test_tool_edit.lua
@@ -208,4 +208,49 @@ T['replace_all']['replaces entire buffer with empty content'] = function()
   vim.api.nvim_buf_delete(bufnr, { force = true })
 end
 
+T['insert']['preserves empty lines in content'] = function()
+  -- Regression: P2 edit.lua dropped empty lines
+  local bufnr = create_test_buffer({ "line1", "line3" })
+
+  local result = edit_tool.run({
+    action = "insert",
+    line = 2,
+    content = "before\n\nafter"
+  })
+
+  MiniTest.expect.equality(result.success, true)
+  MiniTest.expect.equality(result.inserted, 3)
+
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  MiniTest.expect.equality(lines[1], "line1")
+  MiniTest.expect.equality(lines[2], "before")
+  MiniTest.expect.equality(lines[3], "")
+  MiniTest.expect.equality(lines[4], "after")
+  MiniTest.expect.equality(lines[5], "line3")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end
+
+T['replace_all']['preserves empty lines in content'] = function()
+  -- Regression: P2 edit.lua dropped empty lines
+  local bufnr = create_test_buffer({ "old1", "old2" })
+
+  local result = edit_tool.run({
+    action = "replace_all",
+    content = "line1\n\n\nline4"
+  })
+
+  MiniTest.expect.equality(result.success, true)
+  MiniTest.expect.equality(result.lines, 4)
+
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  MiniTest.expect.equality(#lines, 4)
+  MiniTest.expect.equality(lines[1], "line1")
+  MiniTest.expect.equality(lines[2], "")
+  MiniTest.expect.equality(lines[3], "")
+  MiniTest.expect.equality(lines[4], "line4")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end
+
 return T

--- a/tests/test_tool_grep.lua
+++ b/tests/test_tool_grep.lua
@@ -293,4 +293,24 @@ T['grep']['grep preserves custom file_pattern in result'] = function()
   cleanup_temp_files(created_files, temp_dir)
 end
 
+T['grep']['empty pattern does not change cwd'] = function()
+  -- Regression: P1 grep.lua CWD corruption
+  -- Old code would cd to path before validating empty pattern
+  clean_qflist()
+
+  local cwd_before = vim.fn.getcwd()
+  local temp_dir = vim.fn.tempname()
+  vim.fn.mkdir(temp_dir, "p")
+
+  local result = grep_tool.run({
+    pattern = "",
+    path = temp_dir,
+  })
+
+  MiniTest.expect.equality(result.success, false)
+  MiniTest.expect.equality(vim.fn.getcwd(), cwd_before)
+
+  vim.fn.delete(temp_dir, "rf")
+end
+
 return T

--- a/tests/test_tool_tab.lua
+++ b/tests/test_tool_tab.lua
@@ -156,4 +156,22 @@ T['tab']['unknown action returns error'] = function()
   MiniTest.expect.no_equality(result.error, nil)
 end
 
+T['tab']['new with malicious file arg does not execute commands'] = function()
+  -- Regression: P0 command injection fix
+  -- Old code used vim.cmd("tabnew " .. args.file) which allowed injection
+  vim.g._buddy_injection_test = nil
+  local before_tabs = vim.api.nvim_list_tabpages()
+
+  -- This payload would execute arbitrary code with the old string concatenation approach
+  local result = tab_tool.run({ action = "new", file = "test|lua vim.g._buddy_injection_test=1" })
+  MiniTest.expect.equality(result.success, true)
+
+  -- The injection should NOT have executed
+  MiniTest.expect.equality(vim.g._buddy_injection_test, nil)
+
+  -- Cleanup
+  vim.cmd("tabclose")
+  vim.g._buddy_injection_test = nil
+end
+
 return T


### PR DESCRIPTION
## Summary

Addresses structural debt identified in a full architectural audit. This PR covers the **code review audit fixes** plus **Wave 1** of an 8-PR migration plan that decouples transport, protocol, and domain layers.

### What's included

**Code Review Audit (2 commits)**
- Security: Bearer token auth on HTTP server, input validation hardening
- Stability: executor edge cases, safe JSON handling, proxy improvements  
- 8 new test files covering auth, executor, logging, and tool edge cases

**Wave 1 — Structural Refactoring (3 commits)**

- **PR1 — Split MCP Handlers**: Decomposed the ~500-line `mcp/methods.lua` god module into `protocol/mcp/handlers/{core,tools,resources,prompts,completion,notifications}.lua` with a dispatcher, registry, and JSON-RPC module. Backward-compatible facade preserved.
- **PR2 — Runtime Primitives**: Added `runtime/event_bus.lua`, `runtime/state/session_store.lua`, `runtime/state/request_store.lua`, and `protocol/mcp/errors.lua`. Purely additive — no behavior changes.
- **PR3 — Decoupled Client Requester**: Introduced `services/client_requester.lua` and `services/notifier.lua` with injected transport (no direct SSE dependency). Added `transport/sse/hub.lua` adapter. Notifications now flow through the Notifier service.

### Test coverage

| Metric | Before | After |
|--------|--------|-------|
| Test cases | ~130 | **294** |
| Test files | 16 | **28** |
| Failures | 0 | **0** |

### Files changed

55 files changed, +3955 / -664 lines

### Migration plan

This is Wave 1 of 5. Remaining waves (PR4–PR8) cover nvim-nio async migration, async executor, SSE lifecycle hardening, thin router extraction, and end-to-end cancellation. Each wave keeps tests green and preserves the tool author contract (`tool.run(args, context)`).