### PR TITLE
fix: enforce async tool contracts and sync-call cancellation

### DIFF
--- a/docs/creating-tools.md
+++ b/docs/creating-tools.md
@@ -43,7 +43,7 @@ return {
         required = { "name" },
       },
       run = function(args)
-        return { content = { { type = "text", text = "Hello, " .. args.name } } }
+        return "Hello, " .. args.name
       end,
     },
   }
@@ -81,12 +81,12 @@ return {
 
     if action == "chart" then
       -- handle chart
-      return { content = { { type = "text", text = "Chart rendered" } } }
+      return { rendered = true, chart_type = args.type }
     elseif action == "image" then
       -- handle image
-      return { content = { { type = "text", text = "Image displayed" } } }
+      return { rendered = true, path = args.path }
     else
-      return { isError = true, content = { { type = "text", text = "Unknown action: " .. action } } }
+      error("Unknown action: " .. action)
     end
   end,
 }
@@ -167,53 +167,115 @@ Now your tool:
 For long-running operations, either return a cancel function or explicitly
 declare async mode with `context.start_async()`:
 
+### Option 1: Return a Cancel Function
+
+Return a function from `run()` to signal async mode. The function is used for
+cancellation. Call `context(result)` when the work completes.
+
 ```lua
 run = function(args, context)
   -- Start async work
   local handle = start_async_operation(function(result)
     context(result)  -- Call context to complete
   end)
-  -- Return cancel function
+  -- Return cancel function (signals async mode)
   return function()
     handle:cancel()
   end
 end
 ```
 
-For non-cancellable async work, call `context.start_async()` before returning:
+### Option 2: Declare Async with `context.start_async()`
+
+For non-cancellable async work (or when you want to provide a cancel function
+separately), call `context.start_async()` before returning:
 
 ```lua
 run = function(args, context)
-  context.start_async()
+  context.start_async()  -- optional: context.start_async(cancel_fn)
   start_async_operation(function(result)
     context(result)
   end)
-  return nil
+  return nil  -- MUST return nil when start_async() was called
 end
 ```
 
+!!! warning "Return Contract"
+    When `context.start_async()` is called, `run()` **must** return `nil`.
+    Returning a non-nil value after calling `start_async()` is a programming
+    error and will raise an exception.
+
+    When using Option 1 (return cancel function), do **not** also call
+    `context.start_async()` — the return value already signals async mode.
+    If both are used, the returned cancel function takes precedence.
+
+!!! note "Sync tools/call"
+    The MCP `tools/call` endpoint is synchronous. Async tools invoked via
+    `tools/call` are immediately cancelled and an error response is returned.
+    Async tools are intended for use via the callback-based `execute()` or
+    `execute_async()` APIs.
+
 ## Returning Results
 
-### Simple Success
+Tools return **raw Lua values** from `run()`. buddy.nvim automatically wraps
+them into MCP-compatible responses — you do **not** return MCP envelope objects
+(like `{ content = { ... } }`) directly.
+
+### String Results
+
+Returned as-is in a text content block:
+
+```lua
+return "Hello, world!"
+-- → MCP response: { content = [{ type = "text", text = "Hello, world!" }] }
+```
+
+### Table Results
+
+JSON-encoded into a text content block:
 
 ```lua
 return { success = true, data = "result" }
+-- → MCP response: { content = [{ type = "text", text = "{\"success\":true,\"data\":\"result\"}" }] }
 ```
 
-### MCP-Formatted Content
+### Nil Results
+
+Returned as the string `"nil"`:
+
+```lua
+return nil
+-- → MCP response: { content = [{ type = "text", text = "nil" }] }
+```
+
+### Structured Output (with output_schema)
+
+If your tool defines `output_schema`, the table result is also included as
+`structuredContent` in the MCP response:
 
 ```lua
 return {
-  content = {
-    { type = "text", text = "Hello, world!" },
-  }
+  name = "my_tool",
+  output_schema = { type = "object", properties = { count = { type = "number" } } },
+  run = function(args)
+    return { count = 42 }
+    -- → MCP response: { content = [...], structuredContent = { count = 42 } }
+  end,
 }
 ```
 
 ### Errors
 
+To signal a tool error, use `error()` or the structured error API:
+
 ```lua
-return { success = false, error = "Something went wrong" }
+local errors = require("buddy.tools.errors")
+
+-- Option 1: Simple error (becomes isError MCP response)
+error("Something went wrong")
+
+-- Option 2: Structured error with code
+errors.throw(errors.codes.EXECUTION_ERROR, "Something went wrong", { detail = "..." })
 ```
 
 ## Testing Tools

--- a/lua/buddy/protocol/mcp/handlers/tools.lua
+++ b/lua/buddy/protocol/mcp/handlers/tools.lua
@@ -1,6 +1,7 @@
 --- MCP tools handlers: tools/list, tools/call
 local registry = require("buddy.protocol.mcp.registry")
 local tools = require("buddy.tools")
+local log = require("buddy.log")
 
 registry.register("tools/list", function(_session_id, params)
   local _ = params and params.cursor  -- Accept cursor param (unused - no pagination needed)
@@ -38,8 +39,11 @@ registry.register("tools/call", function(session_id, params, request_id)
   local ToolService = require("buddy.services.tool_service")
   local service = ToolService.get_instance()
 
-  -- Fallback: create an unwired instance if no singleton set (e.g., direct tests)
+  -- Fallback: create an unwired instance if no singleton set (e.g., direct tests).
+  -- WARNING: This fallback has no notifier, request_store, or client_requester,
+  -- so progress notifications, cancellation binding, and elicitation will not work.
   if not service then
+    log.debug("tools/call: no ToolService singleton set, using unwired fallback (test-only path)")
     service = ToolService.new()
   end
 

--- a/lua/buddy/services/tool_service.lua
+++ b/lua/buddy/services/tool_service.lua
@@ -75,12 +75,11 @@ function ToolService:call(session_id, params, request_id)
   -- Build executor options with context (no callback — sync dispatch path).
   -- Async tools are detected by executor via cancel-function return value
   -- or explicit context.start_async() declaration.
-  -- and are tracked for cancellation, but results are not delivered here.
   --
-  -- NOTE (known limitation): Async tool outputs are dropped in the MCP tools/call
-  -- sync dispatch path. The handler returns an explicit error response immediately.
-  -- Real async result delivery requires making the dispatch chain nio-aware,
-  -- which is deferred to a future PR. All built-in buddy.nvim tools are synchronous.
+  -- Sync tools/call explicitly rejects async tools: the async task is cancelled
+  -- immediately and an error response is returned. This prevents leaked async
+  -- tasks that have no callback to deliver results to.
+  -- All built-in buddy.nvim tools are synchronous.
   local exec_opts = {
     session_id = session_id,
     request_id = request_id,
@@ -101,12 +100,19 @@ function ToolService:call(session_id, params, request_id)
   -- Request→task binding is handled by executor (bound before tool.run(),
   -- unbound on completion/cancel/failure). No binding needed here.
 
-  -- Async tool: result is nil, task_id is set. Return an explicit error response
-  -- from sync tools/call so clients do not misinterpret this as final tool output.
+  -- Async tool: result is nil, task_id is set.
+  -- Cancel the leaked async task immediately so it doesn't dangle, then return
+  -- an explicit error response from sync tools/call so clients do not
+  -- misinterpret this as final tool output.
   if task_id then
+    self._executor.cancel(task_id)
+    -- Unbind request→task mapping (cancel doesn't have access to request_store)
+    if self._request_store and request_id then
+      self._request_store:unbind_tool_task(session_id, request_id)
+    end
     return errors.to_mcp_response(errors.create(
       errors.codes.EXECUTION_ERROR,
-      "Tool '" .. tool_name .. "' started asynchronously (task " .. task_id .. "), but sync tools/call does not support async results",
+      "Tool '" .. tool_name .. "' is async and cannot be invoked via sync tools/call (task " .. task_id .. " cancelled)",
       { tool = tool_name, task_id = task_id }
     ))
   end

--- a/lua/buddy/tools/executor.lua
+++ b/lua/buddy/tools/executor.lua
@@ -213,6 +213,18 @@ function M.execute(tool_id, args, opts)
       -- The placeholder was cleaned up by async_callback or context __call.
       log.debug("Tool %s completed synchronously inside run() (task %s)", tool_id, task_id)
     end
+
+    -- Transition deferred state so context() calls deliver immediately from
+    -- this point on (prevents permanent deferral when start_async() was also
+    -- called).  Flush any result that was buffered during run().
+    if async_declared then
+      deferred_delivered = true
+      if deferred_result then
+        _deliver_result(deferred_result.result)
+        deferred_result = nil
+      end
+    end
+
     return nil, task_id
   end
 

--- a/lua/buddy/tools/executor.lua
+++ b/lua/buddy/tools/executor.lua
@@ -92,6 +92,11 @@ function M.execute(tool_id, args, opts)
   end
 
   local async_declared = false
+  -- When start_async() is active, defer context(result) calls until after
+  -- run() returns so the mixed-mode guard can reject invalid contracts
+  -- BEFORE any success is delivered.
+  local deferred_result = nil  -- { result = <value> } when pending
+  local deferred_delivered = false
 
   -- Make progress callback available to tool run function
   local context = {
@@ -128,25 +133,41 @@ function M.execute(tool_id, args, opts)
     end
   end
 
+  -- Deliver a completion result: invoke async_callback or clean up running_tasks.
+  -- Also unbinds request→task mapping to prevent binding leaks.
+  local function _deliver_result(result)
+    if async_callback then
+      async_callback(result)
+    else
+      -- No external callback — still clean up running_tasks
+      local task = running_tasks[task_id]
+      if task and not task.cancelled then
+        log.debug("Async tool %s completed without callback (task %s)", tool_id, task_id)
+        running_tasks[task_id] = nil
+      end
+    end
+    -- Unbind request→task mapping on completion (prevents binding leak)
+    if opts.request_store and opts.session_id and opts.request_id then
+      opts.request_store:unbind_tool_task(opts.session_id, opts.request_id)
+    end
+  end
+
   -- Allow tools to use context as a callback for async completion.
   -- Even without an external callback, clean up the running_tasks entry
   -- and unbind from request_store if available.
+  --
+  -- When start_async() has been called, defer delivery until after run()
+  -- returns so the mixed-mode contract guard can reject before success
+  -- is delivered.
   setmetatable(context, {
     __call = function(_, result)
-      if async_callback then
-        async_callback(result)
-      else
-        -- No external callback — still clean up running_tasks
-        local task = running_tasks[task_id]
-        if task and not task.cancelled then
-          log.debug("Async tool %s completed without callback (task %s)", tool_id, task_id)
-          running_tasks[task_id] = nil
-        end
+      if async_declared and not deferred_delivered then
+        -- Buffer the result; it will be flushed after run() returns
+        -- and contract validation passes.
+        deferred_result = { result = result }
+        return
       end
-      -- Unbind request→task mapping on completion (prevents binding leak)
-      if opts.request_store and opts.session_id and opts.request_id then
-        opts.request_store:unbind_tool_task(opts.session_id, opts.request_id)
-      end
+      _deliver_result(result)
     end,
   })
 
@@ -199,8 +220,11 @@ function M.execute(tool_id, args, opts)
   if async_declared then
     -- Mixed-mode guard: if start_async() was called but run() returned a
     -- non-nil, non-function value, that's a programming error — the tool is
-    -- confused about its sync/async contract. Clean up and throw.
+    -- confused about its sync/async contract. Clean up and throw WITHOUT
+    -- delivering any deferred result.
     if cancel_or_result ~= nil then
+      -- Discard any deferred result — contract is invalid.
+      deferred_result = nil
       running_tasks[task_id] = nil
       if opts.request_store and opts.session_id and opts.request_id then
         opts.request_store:unbind_tool_task(opts.session_id, opts.request_id)
@@ -211,6 +235,13 @@ function M.execute(tool_id, args, opts)
           .. "async tools must return nil (got " .. type(cancel_or_result) .. ")",
         { tool = tool_id }
       )
+    end
+
+    -- Contract is valid. Flush any deferred completion from context() calls
+    -- that happened inside run().
+    deferred_delivered = true
+    if deferred_result then
+      _deliver_result(deferred_result.result)
     end
 
     local task = running_tasks[task_id]

--- a/lua/buddy/tools/executor.lua
+++ b/lua/buddy/tools/executor.lua
@@ -197,6 +197,22 @@ function M.execute(tool_id, args, opts)
 
   -- Async tool explicitly declared via context.start_async().
   if async_declared then
+    -- Mixed-mode guard: if start_async() was called but run() returned a
+    -- non-nil, non-function value, that's a programming error — the tool is
+    -- confused about its sync/async contract. Clean up and throw.
+    if cancel_or_result ~= nil then
+      running_tasks[task_id] = nil
+      if opts.request_store and opts.session_id and opts.request_id then
+        opts.request_store:unbind_tool_task(opts.session_id, opts.request_id)
+      end
+      errors.throw(
+        errors.codes.EXECUTION_ERROR,
+        "Tool '" .. tool_id .. "' called context.start_async() but also returned a value; "
+          .. "async tools must return nil (got " .. type(cancel_or_result) .. ")",
+        { tool = tool_id }
+      )
+    end
+
     local task = running_tasks[task_id]
     if task then
       log.debug("Tool %s declared async (task %s)", tool_id, task_id)

--- a/tests/test_cancellation_e2e.lua
+++ b/tests/test_cancellation_e2e.lua
@@ -145,7 +145,7 @@ T['tool_service']['sync tool does not create binding'] = function()
   MiniTest.expect.equality(store:get_tool_task("sess-1", 100), nil)
 end
 
-T['tool_service']['async tool gets bound for cancellation'] = function()
+T['tool_service']['async tool gets cancelled immediately in sync path'] = function()
   local RequestStore = require("buddy.runtime.state.request_store")
   local store = RequestStore.new()
 
@@ -167,17 +167,17 @@ T['tool_service']['async tool gets bound for cancellation'] = function()
   local ToolService = require("buddy.services.tool_service")
   local service = ToolService.new({ request_store = store })
 
-  -- Call should bind the task for cancellation
-  service:call("sess-1", { name = "_test_async_cancel" }, 200)
+  -- Call should detect async, cancel the task, and return error
+  local response = service:call("sess-1", { name = "_test_async_cancel" }, 200)
 
-  -- Async tool should have a binding
-  local task_id = store:get_tool_task("sess-1", 200)
-  MiniTest.expect.equality(type(task_id), "string")
+  -- Should return an error response
+  MiniTest.expect.equality(response.isError, true)
 
-  -- Cancel should work through the binding
-  local cancelled = service:cancel(task_id)
-  MiniTest.expect.equality(cancelled, true)
+  -- Cancel should have been called immediately by tool_service
   MiniTest.expect.equality(cancel_called, true)
+
+  -- Binding should be cleaned up (task was cancelled)
+  MiniTest.expect.equality(store:get_tool_task("sess-1", 200), nil)
 end
 
 T['tool_service']['cancel delegates to executor'] = function()
@@ -450,18 +450,16 @@ end
 -- ToolService: binding cleanup on async completion
 -- ────────────────────────────────────────────────────────────────
 
-T['tool_service']['async binding cleaned up on completion'] = function()
+T['tool_service']['async binding cleaned up immediately in sync path'] = function()
   local RequestStore = require("buddy.runtime.state.request_store")
   local store = RequestStore.new()
 
   local tools = require("buddy.tools")
-  local complete_fn
   tools.register({
     name = "_test_async_unbind",
     description = "Async tool for binding cleanup test",
     args = {},
     run = function(_args, context)
-      complete_fn = function(result) context(result) end
       return function() end
     end,
   })
@@ -469,16 +467,10 @@ T['tool_service']['async binding cleaned up on completion'] = function()
   local ToolService = require("buddy.services.tool_service")
   local service = ToolService.new({ request_store = store })
 
-  service:call("sess-1", { name = "_test_async_unbind" }, 500)
+  local response = service:call("sess-1", { name = "_test_async_unbind" }, 500)
 
-  -- Binding should exist while tool is running
-  local task_id = store:get_tool_task("sess-1", 500)
-  MiniTest.expect.equality(type(task_id), "string")
-
-  -- Complete the async tool
-  complete_fn({ done = true })
-
-  -- Binding should be cleaned up after completion
+  -- Async tool should be immediately cancelled and binding cleaned up
+  MiniTest.expect.equality(response.isError, true)
   MiniTest.expect.equality(store:get_tool_task("sess-1", 500), nil)
 end
 
@@ -573,7 +565,7 @@ T['tool_service']['async tool returns error response in sync path'] = function()
   MiniTest.expect.equality(response.content[1].type, "text")
   MiniTest.expect.equality(type(response.content[1].text), "string")
   MiniTest.expect.equality(response.content[1].text:find("_test_async_response", 1, true) ~= nil, true)
-  MiniTest.expect.equality(response.content[1].text:find("sync tools/call does not support async results", 1, true) ~= nil, true)
+  MiniTest.expect.equality(response.content[1].text:find("async and cannot be invoked via sync tools/call", 1, true) ~= nil, true)
 end
 
 return T

--- a/tests/test_executor.lua
+++ b/tests/test_executor.lua
@@ -144,4 +144,154 @@ T['list_running()']['returns empty list initially'] = function()
   MiniTest.expect.equality(#executor.list_running(), 0)
 end
 
+-- Async via cancel function return
+T['execute()']['async via cancel fn returns nil and task_id'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'async-cancel-tool',
+    description = 'Async tool with cancel fn',
+    run = function(_, _context)
+      return function() end  -- cancel function
+    end,
+  })
+
+  local result, task_id = executor.execute('async-cancel-tool', {}, {
+    callback = function() end,
+  })
+  MiniTest.expect.equality(result, nil)
+  MiniTest.expect.no_equality(task_id, nil)
+
+  -- Task should be tracked
+  local running = executor.list_running()
+  MiniTest.expect.equality(#running, 1)
+  MiniTest.expect.equality(running[1].tool_id, 'async-cancel-tool')
+
+  -- Clean up
+  executor.cancel(task_id)
+end
+
+-- Async via context.start_async()
+T['execute()']['async via start_async returns nil and task_id'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'async-start-tool',
+    description = 'Async tool with start_async',
+    run = function(_, context)
+      context.start_async()
+      return nil
+    end,
+  })
+
+  local result, task_id = executor.execute('async-start-tool', {}, {
+    callback = function() end,
+  })
+  MiniTest.expect.equality(result, nil)
+  MiniTest.expect.no_equality(task_id, nil)
+
+  -- Clean up
+  executor.cancel(task_id)
+end
+
+-- Mixed-mode: start_async + non-nil return is an error
+T['execute()']['start_async with non-nil return throws'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'mixed-mode-tool',
+    description = 'Mixed-mode tool (broken)',
+    run = function(_, context)
+      context.start_async()
+      return { result = "should not be here" }  -- non-nil, non-function
+    end,
+  })
+
+  MiniTest.expect.error(function()
+    executor.execute('mixed-mode-tool', {})
+  end)
+
+  -- Ensure no leaked tasks
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
+-- start_async + function return uses cancel-fn branch precedence
+T['execute()']['start_async with function return uses cancel-fn precedence'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  -- Note: a function return is caught FIRST by the cancel-fn branch (line 184),
+  -- so start_async + function return works — the cancel-fn takes precedence.
+  -- This is the documented behavior: return function = async (cancel fn branch).
+  -- start_async is only checked when return is NOT a function.
+
+  tools.register({
+    name = 'start-async-fn-tool',
+    description = 'start_async + cancel fn',
+    run = function(_, context)
+      context.start_async()
+      return function() end
+    end,
+  })
+
+  -- This should NOT throw — cancel fn branch takes precedence
+  local result, task_id = executor.execute('start-async-fn-tool', {}, {
+    callback = function() end,
+  })
+  MiniTest.expect.equality(result, nil)
+  MiniTest.expect.no_equality(task_id, nil)
+
+  -- Clean up
+  executor.cancel(task_id)
+end
+
+-- start_async with cancel_fn argument
+T['execute()']['start_async with cancel_fn arg registers it'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+  local cancel_called = false
+
+  tools.register({
+    name = 'async-cancel-arg-tool',
+    description = 'Async with cancel fn arg',
+    run = function(_, context)
+      context.start_async(function()
+        cancel_called = true
+      end)
+      return nil
+    end,
+  })
+
+  local _, task_id = executor.execute('async-cancel-arg-tool', {}, {
+    callback = function() end,
+  })
+  MiniTest.expect.no_equality(task_id, nil)
+
+  -- Cancel should invoke the cancel fn
+  executor.cancel(task_id)
+  MiniTest.expect.equality(cancel_called, true)
+end
+
+-- start_async rejects non-function, non-nil argument
+T['execute()']['start_async rejects non-function argument'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'start-async-bad-arg',
+    description = 'start_async with bad arg',
+    run = function(_, context)
+      context.start_async("not a function")
+      return nil
+    end,
+  })
+
+  MiniTest.expect.error(function()
+    executor.execute('start-async-bad-arg', {})
+  end)
+end
+
 return T

--- a/tests/test_executor.lua
+++ b/tests/test_executor.lua
@@ -294,4 +294,137 @@ T['execute()']['start_async rejects non-function argument'] = function()
   end)
 end
 
+-- Mixed-mode guard with deferred delivery:
+-- start_async() + context(result) inside run() + non-nil return → error, not success
+T['execute()']['start_async + context(result) + non-nil return is error not success'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'mixed-mode-deferred',
+    description = 'Mixed-mode: start_async, deliver, then return value',
+    run = function(_, context)
+      context.start_async()
+      context({ success = true, data = "should be discarded" })
+      return { bad = true }  -- contract violation
+    end,
+  })
+
+  -- Via execute() with callback: should throw, callback should NOT receive success
+  local callback_calls = {}
+  MiniTest.expect.error(function()
+    executor.execute('mixed-mode-deferred', {}, {
+      callback = function(err, result)
+        table.insert(callback_calls, { err = err, result = result })
+      end,
+    })
+  end)
+
+  -- Callback should never have been called with the deferred result
+  MiniTest.expect.equality(#callback_calls, 0)
+
+  -- No leaked tasks
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
+-- Same scenario via execute_async: future resolves as error, not success
+T['execute()']['execute_async: start_async + context(result) + non-nil return resolves as error'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'mixed-mode-async-future',
+    description = 'Mixed-mode via execute_async',
+    run = function(_, context)
+      context.start_async()
+      context({ success = true, data = "should be discarded" })
+      return { bad = true }  -- contract violation
+    end,
+  })
+
+  local future, task_id = executor.execute_async('mixed-mode-async-future', {})
+
+  -- Future should be set (error path)
+  MiniTest.expect.equality(future.is_set(), true)
+  local packed = future.wait()
+
+  -- Should be an error, NOT a success result
+  MiniTest.expect.no_equality(packed.error, nil)
+  MiniTest.expect.equality(packed.result, nil)
+
+  -- task_id should be nil (thrown synchronously, no async tracking)
+  MiniTest.expect.equality(task_id, nil)
+
+  -- No leaked tasks
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
+-- Deferred delivery works for valid contract: start_async + context(result) + return nil
+T['execute()']['start_async + context(result) + return nil delivers result'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'deferred-valid',
+    description = 'Valid: start_async, deliver inside run, return nil',
+    run = function(_, context)
+      context.start_async()
+      context({ deferred = true })
+      return nil
+    end,
+  })
+
+  local callback_calls = {}
+  local _, task_id = executor.execute('deferred-valid', {}, {
+    callback = function(err, result)
+      table.insert(callback_calls, { err = err, result = result })
+    end,
+  })
+
+  MiniTest.expect.no_equality(task_id, nil)
+
+  -- Callback should have been invoked with the deferred result
+  MiniTest.expect.equality(#callback_calls, 1)
+  MiniTest.expect.equality(callback_calls[1].err, nil)
+  MiniTest.expect.equality(callback_calls[1].result, { deferred = true })
+
+  -- No leaked tasks
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
+-- Post-run context() calls still work for start_async tools (non-deferred path)
+T['execute()']['start_async late context() call still delivers'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+  local complete_fn
+
+  tools.register({
+    name = 'deferred-late',
+    description = 'start_async with late completion',
+    run = function(_, context)
+      context.start_async()
+      complete_fn = function(result) context(result) end
+      return nil
+    end,
+  })
+
+  local callback_calls = {}
+  local _, task_id = executor.execute('deferred-late', {}, {
+    callback = function(err, result)
+      table.insert(callback_calls, { err = err, result = result })
+    end,
+  })
+
+  MiniTest.expect.no_equality(task_id, nil)
+  -- No callback yet — context() not called inside run()
+  MiniTest.expect.equality(#callback_calls, 0)
+
+  -- Late completion after run() returned
+  complete_fn({ late = true })
+
+  MiniTest.expect.equality(#callback_calls, 1)
+  MiniTest.expect.equality(callback_calls[1].result, { late = true })
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
 return T

--- a/tests/test_executor.lua
+++ b/tests/test_executor.lua
@@ -248,6 +248,80 @@ T['execute()']['start_async with function return uses cancel-fn precedence'] = f
   executor.cancel(task_id)
 end
 
+-- Regression: start_async + function return + immediate context(result) delivers and no leak
+T['execute()']['start_async + fn return + immediate context delivers'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+
+  tools.register({
+    name = 'async-fn-imm-ctx',
+    description = 'start_async + cancel fn + immediate context(result)',
+    run = function(_, context)
+      context.start_async()
+      context({ immediate = true })
+      return function() end  -- cancel function
+    end,
+  })
+
+  local callback_calls = {}
+  local _, task_id = executor.execute('async-fn-imm-ctx', {}, {
+    callback = function(err, result)
+      table.insert(callback_calls, { err = err, result = result })
+    end,
+  })
+
+  MiniTest.expect.no_equality(task_id, nil)
+
+  -- Callback should have been invoked with the deferred result (flushed after run)
+  MiniTest.expect.equality(#callback_calls, 1)
+  MiniTest.expect.equality(callback_calls[1].err, nil)
+  MiniTest.expect.equality(callback_calls[1].result, { immediate = true })
+
+  -- No leaked tasks
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
+-- Regression: start_async + function return + late context(result) delivers and no leak
+T['execute()']['start_async + fn return + late context delivers'] = function()
+  local tools = get_tools()
+  local executor = get_executor()
+  local complete_fn
+
+  tools.register({
+    name = 'async-fn-late-ctx',
+    description = 'start_async + cancel fn + late context(result)',
+    run = function(_, context)
+      context.start_async()
+      complete_fn = function(result) context(result) end
+      return function() end  -- cancel function
+    end,
+  })
+
+  local callback_calls = {}
+  local _, task_id = executor.execute('async-fn-late-ctx', {}, {
+    callback = function(err, result)
+      table.insert(callback_calls, { err = err, result = result })
+    end,
+  })
+
+  MiniTest.expect.no_equality(task_id, nil)
+  -- No callback yet — context() not called inside run()
+  MiniTest.expect.equality(#callback_calls, 0)
+
+  -- Task should still be running (not leaked, not prematurely cleaned)
+  MiniTest.expect.equality(#executor.list_running(), 1)
+
+  -- Late completion after run() returned
+  complete_fn({ late = true })
+
+  MiniTest.expect.equality(#callback_calls, 1)
+  MiniTest.expect.equality(callback_calls[1].err, nil)
+  MiniTest.expect.equality(callback_calls[1].result, { late = true })
+
+  -- No leaked tasks
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
 -- start_async with cancel_fn argument
 T['execute()']['start_async with cancel_fn arg registers it'] = function()
   local tools = get_tools()

--- a/tests/test_mcp_handlers_tools.lua
+++ b/tests/test_mcp_handlers_tools.lua
@@ -170,4 +170,23 @@ T['tools/call']['includes structuredContent for tools with output_schema'] = fun
   MiniTest.expect.equality(response.result.structuredContent.data, 'test')
 end
 
+T['tools/call']['rejects async tool with isError response'] = function()
+  local tools = require('buddy.tools')
+  local executor = require('buddy.tools.executor')
+  executor._reset()
+  tools.clear()
+  tools.register({
+    name = 'async-tool',
+    description = 'Async tool',
+    run = function(_, _context)
+      return function() end  -- cancel fn = async
+    end,
+  })
+
+  local response = mcp_request('s1', 7, 'tools/call', { name = 'async-tool' })
+  MiniTest.expect.equality(response.result.isError, true)
+  -- Task should not be leaked
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
 return T

--- a/tests/test_tool_service.lua
+++ b/tests/test_tool_service.lua
@@ -195,4 +195,44 @@ T['cancel()']['delegates to executor'] = function()
   MiniTest.expect.equality(ok, false)
 end
 
+T['call()']['rejects async tool via cancel fn with isError and cancels task'] = function()
+  local ToolService = require('buddy.services.tool_service')
+  local executor = require('buddy.tools.executor')
+  executor._reset()
+
+  setup_tool('async-cancel', function(_, _context)
+    return function() end  -- cancel function = async
+  end)
+
+  local svc = ToolService.new()
+  local result = svc:call('s1', { name = 'async-cancel' }, 1)
+
+  -- Should return error
+  MiniTest.expect.equality(result.isError, true)
+  MiniTest.expect.equality(type(result.content[1].text), 'string')
+
+  -- Async task should be cancelled (not leaked)
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
+T['call()']['rejects async tool via start_async with isError and cancels task'] = function()
+  local ToolService = require('buddy.services.tool_service')
+  local executor = require('buddy.tools.executor')
+  executor._reset()
+
+  setup_tool('async-start', function(_, context)
+    context.start_async()
+    return nil
+  end)
+
+  local svc = ToolService.new()
+  local result = svc:call('s1', { name = 'async-start' }, 1)
+
+  -- Should return error
+  MiniTest.expect.equality(result.isError, true)
+
+  -- Async task should be cancelled (not leaked)
+  MiniTest.expect.equality(#executor.list_running(), 0)
+end
+
 return T


### PR DESCRIPTION
## Summary
- cancel async tasks immediately when they are invoked through sync `tools/call`, returning a clear `isError` response and cleaning request→task bindings
- enforce `context.start_async()` contract in the executor by rejecting mixed-mode returns (`start_async()` + non-nil value)
- align tool author docs with actual return-shaping behavior (raw Lua values, no MCP envelope passthrough) and document sync `tools/call` async rejection semantics
- add regression tests across executor, tool service, MCP handlers, and cancellation e2e coverage

## Verification
- `make test`