### PR TITLE
docs: refresh README and tool examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,15 +152,15 @@ By default, buddy.nvim binds to `127.0.0.1` (localhost only). This means only lo
 **To expose on LAN** (e.g., for remote AI clients):
 
 ```lua
-require("nvim-buddy").setup({
+require("buddy").setup({
   host = "0.0.0.0",  -- Listen on all interfaces
 })
 ```
 
-⚠️ **Warning**: There is no authentication or TLS. If you bind to `0.0.0.0`, anyone on your network can control your editor. Consider:
-- Using a firewall to restrict access
-- SSH tunneling for remote access
-- Only enabling on trusted networks
+> **Warning**: There is no authentication or TLS. If you bind to `0.0.0.0`, anyone on your network can control your editor. Consider:
+> - Using a firewall to restrict access
+> - SSH tunneling for remote access
+> - Only enabling on trusted networks
 
 ---
 
@@ -184,13 +184,15 @@ require("nvim-buddy").setup({
 | `status`      | Get cursor, mode, marks, registers             |
 | `init`        | Scaffold new user tools                        |
 
+See [docs/tools.md](docs/tools.md) for full reference with MCP JSON examples.
+
 ---
 
 ## Creating Tools
 
-Tools are defined in a `buddy.lua` file at `lua/{plugin}/buddy.lua`. nvim-buddy discovers these automatically.
+Tools live in `lua/{plugin}/buddy.lua` files. buddy.nvim discovers them automatically from the runtimepath.
 
-### Format 1: Simple Tools List
+### Format 1: Tools List
 
 For plugins with one or more independent tools:
 
@@ -209,71 +211,66 @@ return {
         required = { "name" },
       },
       run = function(args)
-        return { content = { { type = "text", text = "Hello, " .. args.name } } }
+        return "Hello, " .. args.name
+      end,
+    },
+    {
+      name = "farewell",
+      description = "Say goodbye",
+      input_schema = {
+        type = "object",
+        properties = {
+          name = { type = "string", description = "Name to farewell" },
+        },
+        required = { "name" },
+      },
+      run = function(args)
+        return "Goodbye, " .. args.name
       end,
     },
   }
 }
 ```
 
-### Format 2: Action-Based Tool (Recommended for Multi-Action Tools)
+### Format 2: Single Tool
 
-For tools with multiple related actions, use the action-based pattern:
+For plugins that expose exactly one tool:
 
 ```lua
--- lua/viz/buddy.lua
+-- lua/my-plugin/buddy.lua
 return {
-  name = "viz",
-  description = "Visualization tool for images, charts, and diagrams",
-  actions = {
-    image = require("viz.tools.image"),
-    chart = require("viz.tools.chart"),
-  },
-}
-
--- lua/viz/tools/image.lua
-return {
-  description = "Display a local image",
+  name = "my_tool",
+  description = "Does a thing",
   input_schema = {
     type = "object",
     properties = {
-      path = { type = "string", description = "Path to image file" },
+      message = { type = "string", description = "Message to show" },
     },
-    required = { "path" },
+    required = {},
   },
   run = function(args)
-    -- implementation
+    vim.notify("Did the thing with: " .. (args.message or "nothing"))
+    return { success = true }
   end,
 }
 ```
 
-The framework auto-generates:
-- Unified input_schema from all actions
-- Action enum with descriptions (e.g., `"image: Display a local image, chart: Generate charts"`)
-- Routing to the correct action handler
-- Per-action validation with helpful error messages
+### Returning Results
 
-### Tool Format
-
-Individual tools (or actions) use this format:
+Tools return **raw Lua values**. buddy.nvim wraps them into MCP responses automatically:
 
 ```lua
-return {
-  name = "tool_name",           -- Tool name (optional for actions)
-  description = "What it does", -- Required
-  input_schema = {              -- JSON Schema for parameters
-    type = "object",
-    properties = {
-      param1 = { type = "string", description = "A parameter" },
-      action = { type = "string", enum = { "a", "b" }, description = "a: do A, b: do B" },
-    },
-    required = { "action" },
-  },
-  run = function(args)          -- Handler function
-    return { success = true, result = "..." }
-  end,
-}
+-- String → text content block
+return "Hello, world!"
+
+-- Table → JSON-encoded text content block
+return { success = true, data = "result" }
+
+-- nil → text content block with "nil"
+return nil
 ```
+
+> **Common mistake**: Don't return MCP envelopes like `{ content = { { type = "text", text = "..." } } }` from your tools. Just return the raw value. buddy.nvim wraps it for you.
 
 ### Adding Keymaps, Commands, Autocmds
 
@@ -319,17 +316,19 @@ Now your tool:
 
 Edit the file, keymaps and commands update automatically. No restart needed.
 
+See [docs/creating-tools.md](docs/creating-tools.md) for the full guide.
+
 ---
 
 ## Configuration
 
 ```lua
-local buddy = require("buddy")
-
-buddy.setup({
+require("buddy").setup({
   host = "127.0.0.1",  -- Bind address (default: "127.0.0.1" for security)
   port = 7234,         -- Server port (default: 7234)
   auto_start = false,  -- Start on VimEnter (default: false)
+  auth = true,         -- Bearer token auth on HTTP endpoints (default: true)
+  watch = true,        -- Hot reload file watching (default: true)
   log_level = "info",  -- Log level: "debug", "info", "warn", "error"
   tools = {
     disabled = {},     -- Disable specific tools: {"grep", "diagnostics", ...}
@@ -361,6 +360,9 @@ buddy.restart()
 -- Check status
 local status = buddy.status()
 -- { running = true, port = 7234 }
+
+-- Call a tool programmatically
+local result = buddy.call("buffer", { action = "list" })
 
 -- Register a tool programmatically
 buddy.register_tool({
@@ -409,7 +411,7 @@ Check `:messages` for errors. Common issues:
 ### SSE connection failing
 
 Ensure:
-1. nvim-buddy is running (`:lua print(require('nvim-buddy').status().running)`)
+1. buddy.nvim is running: `:lua print(require('buddy').status().running)`
 2. The URL matches your config (default: `http://127.0.0.1:7234/sse`)
 3. No firewall blocking the connection
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Add to your Claude Desktop config:
 
 Connect directly to a specific Neovim instance by URL. Simpler, but you must know the port and can only connect to one session.
 
+> **Note**: With auth enabled (default), the client must send an `Authorization: Bearer <token>` header. The proxy handles this automatically; for direct connections, either configure your client's auth headers or disable auth in trusted local setups.
+
 #### OpenCode
 
 ```jsonc
@@ -157,7 +159,7 @@ require("buddy").setup({
 })
 ```
 
-> **Warning**: There is no authentication or TLS. If you bind to `0.0.0.0`, anyone on your network can control your editor. Consider:
+> **Note**: Bearer token authentication is enabled by default (`auth = true`), but there is no TLS. If you bind to `0.0.0.0`, the token is sent in plaintext. Consider:
 > - Using a firewall to restrict access
 > - SSH tunneling for remote access
 > - Only enabling on trusted networks
@@ -368,12 +370,11 @@ local result = buddy.call("buffer", { action = "list" })
 buddy.register_tool({
   name = "my_tool",
   description = "Does something",
-  input_schema = {
-    type = "object",
-    properties = {},
-    required = {},
+  args = {
+    param = { type = "string", description = "A parameter" },
   },
-  run = function(args) return { success = true } end,
+  required = { "param" },
+  run = function(args) return { success = true, param = args.param } end,
 })
 ```
 

--- a/doc/buddy.txt
+++ b/doc/buddy.txt
@@ -147,6 +147,10 @@ OPTION B: DIRECT SSE CONNECTION ~
 Connect directly to a specific Neovim instance by URL. Simpler, but you must
 know the port and can only connect to one session.
 
+⚠️ **Note**: With auth enabled (default), direct connections must send
+`Authorization: Bearer <token>`. If your MCP client cannot send auth headers,
+use `buddy-mcp-proxy`.
+
 
 OPENCODE
 
@@ -184,15 +188,15 @@ local processes can connect.
 **To expose on LAN** (e.g., for remote AI clients):
 
 >lua
-    require("nvim-buddy").setup({
+    require("buddy").setup({
       host = "0.0.0.0",  -- Listen on all interfaces
     })
 <
 
-⚠️ **Warning**: There is no authentication or TLS. If you bind to
-`0.0.0.0`, anyone on your network can control your editor. Consider: - Using a
-firewall to restrict access - SSH tunneling for remote access - Only enabling
-on trusted networks
+⚠️ **Note**: Bearer token authentication is enabled by default (`auth = true`),
+but there is no TLS. If you bind to `0.0.0.0`, the token is sent in plaintext.
+Consider: - Using a firewall to restrict access - SSH tunneling for remote
+access - Only enabling on trusted networks
 
 ------------------------------------------------------------------------------
 
@@ -219,11 +223,11 @@ BUILT-IN TOOLS                               *buddy-buddy.nvim-built-in-tools*
 
 CREATING TOOLS                               *buddy-buddy.nvim-creating-tools*
 
-Tools are defined in a `buddy.lua` file at `lua/{plugin}/buddy.lua`. nvim-buddy
+Tools are defined in a `buddy.lua` file at `lua/{plugin}/buddy.lua`. buddy
 discovers these automatically.
 
 
-FORMAT 1: SIMPLE TOOLS LIST ~
+FORMAT 1: TOOLS LIST ~
 
 For plugins with one or more independent tools:
 
@@ -242,7 +246,7 @@ For plugins with one or more independent tools:
             required = { "name" },
           },
           run = function(args)
-            return { content = { { type = "text", text = "Hello, " .. args.name } } }
+            return "Hello, " .. args.name
           end,
         },
       }
@@ -250,50 +254,36 @@ For plugins with one or more independent tools:
 <
 
 
-FORMAT 2: ACTION-BASED TOOL (RECOMMENDED FOR MULTI-ACTION TOOLS) ~
+FORMAT 2: SINGLE TOOL ~
 
-For tools with multiple related actions, use the action-based pattern:
+For plugins that expose exactly one tool:
 
 >lua
-    -- lua/viz/buddy.lua
     return {
-      name = "viz",
-      description = "Visualization tool for images, charts, and diagrams",
-      actions = {
-        image = require("viz.tools.image"),
-        chart = require("viz.tools.chart"),
-      },
-    }
-    
-    -- lua/viz/tools/image.lua
-    return {
-      description = "Display a local image",
+      name = "my_tool",
+      description = "Does something",
       input_schema = {
         type = "object",
         properties = {
-          path = { type = "string", description = "Path to image file" },
+          message = { type = "string", description = "Message to show" },
         },
-        required = { "path" },
+        required = {},
       },
       run = function(args)
-        -- implementation
+        vim.notify(args.message or "hello")
+        return { success = true }
       end,
     }
 <
 
-The framework auto-generates: - Unified input_schema from all actions - Action
-enum with descriptions (e.g., `"image: Display a local image, chart: Generate
-charts"`) - Routing to the correct action handler - Per-action validation with
-helpful error messages
-
 
 TOOL FORMAT ~
 
-Individual tools (or actions) use this format:
+Individual tools use this format:
 
 >lua
     return {
-      name = "tool_name",           -- Tool name (optional for actions)
+      name = "tool_name",           -- Tool name
       description = "What it does", -- Required
       input_schema = {              -- JSON Schema for parameters
         type = "object",
@@ -362,6 +352,8 @@ CONFIGURATION                                 *buddy-buddy.nvim-configuration*
       host = "127.0.0.1",  -- Bind address (default: "127.0.0.1" for security)
       port = 7234,         -- Server port (default: 7234)
       auto_start = false,  -- Start on VimEnter (default: false)
+      auth = true,         -- Bearer token auth on HTTP endpoints (default: true)
+      watch = true,        -- Hot reload file watching (default: true)
       log_level = "info",  -- Log level: "debug", "info", "warn", "error"
       tools = {
         disabled = {},     -- Disable specific tools: {"grep", "diagnostics", ...}
@@ -399,12 +391,11 @@ API                                                     *buddy-buddy.nvim-api*
     buddy.register_tool({
       name = "my_tool",
       description = "Does something",
-      input_schema = {
-        type = "object",
-        properties = {},
-        required = {},
+      args = {
+        param = { type = "string", description = "A parameter" },
       },
-      run = function(args) return { success = true } end,
+      required = { "param" },
+      run = function(args) return { success = true, param = args.param } end,
     })
 <
 
@@ -443,8 +434,8 @@ Check `:messages` for errors. Common issues: - Syntax errors in your tool file
 
 SSE CONNECTION FAILING ~
 
-Ensure: 1. nvim-buddy is running (`:lua
-print(require('nvim-buddy').status().running)`) 2. The URL matches your config
+Ensure: 1. buddy.nvim is running (`:lua
+print(require('buddy').status().running)`) 2. The URL matches your config
 (default: `http://127.0.0.1:7234/sse`) 3. No firewall blocking the connection
 
 ------------------------------------------------------------------------------

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,12 +3,12 @@
 ## Setup Options
 
 ```lua
-local buddy = require("buddy")
-
-buddy.setup({
+require("buddy").setup({
   host = "127.0.0.1",   -- Bind address (default: "127.0.0.1" for security)
   port = 7234,          -- Server port (default: 7234)
   auto_start = false,   -- Start on VimEnter (default: false)
+  auth = true,          -- Bearer token auth on HTTP endpoints (default: true)
+  watch = true,         -- Hot reload file watching (default: true)
   log_level = "info",   -- Log level: "debug", "info", "warn", "error" (default: "info")
   tools = {
     disabled = {},      -- List of tool names to disable (e.g., {"grep", "diagnostics"})
@@ -26,6 +26,8 @@ buddy.setup({
 | `host` | string | `"127.0.0.1"` | Server bind address |
 | `port` | number | `7234` | Server port |
 | `auto_start` | boolean | `false` | Auto-start server on VimEnter |
+| `auth` | boolean | `true` | Enable Bearer token auth on HTTP endpoints |
+| `watch` | boolean | `true` | Enable hot reload file watching |
 | `log_level` | string | `"info"` | Log level: `"debug"`, `"info"`, `"warn"`, `"error"` |
 | `tools.disabled` | string[] | `{}` | List of built-in tool names to disable |
 | `buffer.ignored_filetypes` | string[] | `{}` | Filetypes to exclude from buffer listings |
@@ -65,6 +67,8 @@ Note: Tools from companion plugins (like `buddy_manager`, `viz`, `dotfyle_search
 
 By default, buddy.nvim binds to `127.0.0.1` (localhost only). This means only local processes can connect.
 
+When `auth` is enabled (default), the server generates a random Bearer token on startup. The proxy (`buddy-mcp-proxy`) reads this token automatically from the session registry. Direct SSE connections also pass the token via the session registry.
+
 !!! warning "Exposing on LAN"
     To expose on LAN (e.g., for remote AI clients):
 
@@ -74,7 +78,7 @@ By default, buddy.nvim binds to `127.0.0.1` (localhost only). This means only lo
     })
     ```
 
-    **Warning**: There is no authentication or TLS. If you bind to `0.0.0.0`, anyone on your network can control your editor. Consider:
+    **Warning**: Even with `auth = true`, there is no TLS. If you bind to `0.0.0.0`, consider:
 
     - Using a firewall to restrict access
     - SSH tunneling for remote access
@@ -98,6 +102,9 @@ buddy.restart()
 local status = buddy.status()
 -- { running = true, port = 7234 }
 
+-- Call a tool programmatically
+local result = buddy.call("buffer", { action = "list" })
+
 -- Register a tool programmatically
 buddy.register_tool({
   name = "my_tool",
@@ -105,9 +112,6 @@ buddy.register_tool({
   input_schema = { type = "object", properties = {} },
   run = function(args) return { success = true } end,
 })
-
--- Call a tool programmatically
-local result = buddy.call("my_tool", { some_arg = "value" })
 ```
 
 ## Troubleshooting

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ Note: Tools from companion plugins (like `buddy_manager`, `viz`, `dotfyle_search
 
 By default, buddy.nvim binds to `127.0.0.1` (localhost only). This means only local processes can connect.
 
-When `auth` is enabled (default), the server generates a random Bearer token on startup. The proxy (`buddy-mcp-proxy`) reads this token automatically from the session registry. Direct SSE connections also pass the token via the session registry.
+When `auth` is enabled (default), the server requires an `Authorization: Bearer <token>` header on HTTP/SSE requests. The proxy (`buddy-mcp-proxy`) reads the token from the session registry and injects it automatically. For direct URL connections, your MCP client must support custom auth headers (or you must disable auth in trusted local setups).
 
 !!! warning "Exposing on LAN"
     To expose on LAN (e.g., for remote AI clients):
@@ -109,8 +109,11 @@ local result = buddy.call("buffer", { action = "list" })
 buddy.register_tool({
   name = "my_tool",
   description = "Does something",
-  input_schema = { type = "object", properties = {} },
-  run = function(args) return { success = true } end,
+  args = {
+    param = { type = "string", description = "A parameter" },
+  },
+  required = { "param" },
+  run = function(args) return { success = true, param = args.param } end,
 })
 ```
 

--- a/docs/creating-tools.md
+++ b/docs/creating-tools.md
@@ -1,30 +1,38 @@
 # Creating Tools
 
-Tools are defined in a `buddy.lua` file at `lua/{plugin}/buddy.lua`. buddy.nvim discovers these automatically.
+buddy.nvim discovers tools automatically from `lua/*/buddy.lua` files in the runtimepath.
+
+## Discovery
+
+On startup, buddy.nvim scans `lua/*/buddy.lua` across Neovim's runtimepath. Each file should return either:
+
+- A **tools list**: `{ tools = { tool1, tool2, ... } }` — registers multiple tools
+- A **single tool**: `{ name = "...", description = "...", run = function ... }` — registers one tool
 
 ## Basic Tool Structure
 
+Every tool needs `name`, `description`, `input_schema`, and `run`:
+
 ```lua
 return {
-  name = "tool_name",           -- Tool name (required)
-  description = "What it does", -- Required
-  input_schema = {              -- JSON Schema for parameters
+  name = "tool_name",
+  description = "What it does",
+  input_schema = {
     type = "object",
     properties = {
       param1 = { type = "string", description = "A parameter" },
-      action = { type = "string", enum = { "a", "b" }, description = "a: do A, b: do B" },
     },
-    required = { "action" },
+    required = { "param1" },
   },
-  run = function(args)          -- Handler function
-    return { success = true, result = "..." }
+  run = function(args)
+    return { success = true, result = args.param1 }
   end,
 }
 ```
 
 ## Tool Formats
 
-### Format 1: Simple Tools List
+### Format 1: Tools List
 
 For plugins with one or more independent tools:
 
@@ -46,13 +54,50 @@ return {
         return "Hello, " .. args.name
       end,
     },
+    {
+      name = "farewell",
+      description = "Say goodbye",
+      input_schema = {
+        type = "object",
+        properties = {
+          name = { type = "string", description = "Name to farewell" },
+        },
+        required = { "name" },
+      },
+      run = function(args)
+        return "Goodbye, " .. args.name
+      end,
+    },
   }
 }
 ```
 
-### Format 2: Action-Based Tool
+### Format 2: Single Tool
 
-For tools with multiple related actions, define a single `input_schema` with an `action` enum and route manually in your `run` function:
+For plugins that expose exactly one tool:
+
+```lua
+-- lua/my-plugin/buddy.lua
+return {
+  name = "my_tool",
+  description = "Does something useful",
+  input_schema = {
+    type = "object",
+    properties = {
+      message = { type = "string", description = "Message to show" },
+    },
+    required = {},
+  },
+  run = function(args)
+    vim.notify(args.message or "hello")
+    return { success = true }
+  end,
+}
+```
+
+### Multi-Action Tools
+
+For tools with multiple related actions, define an `action` enum in your `input_schema` and route manually in your `run` function:
 
 ```lua
 -- lua/buddy_viz/buddy.lua
@@ -92,7 +137,10 @@ return {
 }
 ```
 
-This pattern keeps all action logic in one file with explicit routing via if/elseif
+This pattern keeps all action logic in one file with explicit routing via if/elseif. All built-in buddy.nvim tools use this pattern.
+
+!!! warning "No auto-generated routing"
+    There is no auto-generated action routing or schema merging. You define the `action` enum, its `input_schema`, and the routing logic yourself. This keeps things explicit and debuggable.
 
 ## Parameter Types
 
@@ -154,13 +202,79 @@ return {
 
 Now your tool:
 
-- ✅ Works via MCP when AI calls `my_tool`
-- ✅ Works via `<leader>mt` keymap
-- ✅ Works via `:MyTool` command
-- ✅ Runs on `BufEnter` for markdown files
+- Works via MCP when AI calls `my_tool`
+- Works via `<leader>mt` keymap
+- Works via `:MyTool` command
+- Runs on `BufEnter` for markdown files
 
 !!! tip "Hot Reload"
     Edit the file, keymaps and commands update automatically. No restart needed.
+
+## Returning Results
+
+Tools return **raw Lua values** from `run()`. buddy.nvim automatically wraps
+them into MCP-compatible responses. You do **not** return MCP envelope objects
+(like `{ content = { ... } }`) directly.
+
+### String Results
+
+Returned as-is in a text content block:
+
+```lua
+return "Hello, world!"
+-- MCP response: { content = [{ type = "text", text = "Hello, world!" }] }
+```
+
+### Table Results
+
+JSON-encoded into a text content block:
+
+```lua
+return { success = true, data = "result" }
+-- MCP response: { content = [{ type = "text", text = "{\"success\":true,\"data\":\"result\"}" }] }
+```
+
+### Nil Results
+
+Returned as the string `"nil"`:
+
+```lua
+return nil
+-- MCP response: { content = [{ type = "text", text = "nil" }] }
+```
+
+### Structured Output (with output_schema)
+
+If your tool defines `output_schema`, the table result is also included as
+`structuredContent` in the MCP response:
+
+```lua
+return {
+  name = "my_tool",
+  output_schema = { type = "object", properties = { count = { type = "number" } } },
+  run = function(args)
+    return { count = 42 }
+    -- MCP response: { content = [...], structuredContent = { count = 42 } }
+  end,
+}
+```
+
+!!! warning "Common Mistake"
+    Don't return MCP envelopes like `{ content = { { type = "text", text = "..." } } }` from your tool's `run()` function. buddy.nvim wraps results for you automatically. If you return an envelope, it will be double-wrapped.
+
+### Errors
+
+To signal a tool error, use `error()` or the structured error API:
+
+```lua
+local errors = require("buddy.tools.errors")
+
+-- Option 1: Simple error (becomes isError MCP response)
+error("Something went wrong")
+
+-- Option 2: Structured error with code
+errors.throw(errors.codes.EXECUTION_ERROR, "Something went wrong", { detail = "..." })
+```
 
 ## Async Tools
 
@@ -214,69 +328,6 @@ end
     `tools/call` are immediately cancelled and an error response is returned.
     Async tools are intended for use via the callback-based `execute()` or
     `execute_async()` APIs.
-
-## Returning Results
-
-Tools return **raw Lua values** from `run()`. buddy.nvim automatically wraps
-them into MCP-compatible responses — you do **not** return MCP envelope objects
-(like `{ content = { ... } }`) directly.
-
-### String Results
-
-Returned as-is in a text content block:
-
-```lua
-return "Hello, world!"
--- → MCP response: { content = [{ type = "text", text = "Hello, world!" }] }
-```
-
-### Table Results
-
-JSON-encoded into a text content block:
-
-```lua
-return { success = true, data = "result" }
--- → MCP response: { content = [{ type = "text", text = "{\"success\":true,\"data\":\"result\"}" }] }
-```
-
-### Nil Results
-
-Returned as the string `"nil"`:
-
-```lua
-return nil
--- → MCP response: { content = [{ type = "text", text = "nil" }] }
-```
-
-### Structured Output (with output_schema)
-
-If your tool defines `output_schema`, the table result is also included as
-`structuredContent` in the MCP response:
-
-```lua
-return {
-  name = "my_tool",
-  output_schema = { type = "object", properties = { count = { type = "number" } } },
-  run = function(args)
-    return { count = 42 }
-    -- → MCP response: { content = [...], structuredContent = { count = 42 } }
-  end,
-}
-```
-
-### Errors
-
-To signal a tool error, use `error()` or the structured error API:
-
-```lua
-local errors = require("buddy.tools.errors")
-
--- Option 1: Simple error (becomes isError MCP response)
-error("Something went wrong")
-
--- Option 2: Structured error with code
-errors.throw(errors.codes.EXECUTION_ERROR, "Something went wrong", { detail = "..." })
-```
 
 ## Testing Tools
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,24 +19,34 @@ You write tools in Lua. They work as MCP tools (AI calls them) *and* as regular 
 ## Quick Start
 
 ```lua
-require("buddy").setup({
-  auto_start = true,
-  port = 7234,
-})
+-- lazy.nvim
+{
+  "arismoko/buddy.nvim",
+  dependencies = { "echasnovski/mini.nvim", "nvim-neotest/nvim-nio" },
+  lazy = false,
+  config = function()
+    require("buddy").setup({
+      auto_start = true,
+      port = 7234,
+    })
+  end,
+}
 ```
+
+Then connect your MCP client (see [Installation](installation.md) for OpenCode, Claude Desktop, and proxy setup).
 
 ## Features
 
-- 🔌 **MCP Protocol** - Full Model Context Protocol implementation via HTTP/SSE
-- 🛠️ **Built-in Tools** - Buffer, edit, navigation, search, diagnostics, and more
-- 🎯 **Dual Interface** - Same tool works via MCP and Neovim keymaps/commands
-- 🔧 **Extensible** - Create custom tools in Lua with simple API
-- 🔄 **Hot Reload** - Edit tool files, keymaps update automatically
-- 🔒 **Secure** - Localhost-only by default
+- **MCP Protocol** - Full Model Context Protocol implementation via HTTP/SSE
+- **Built-in Tools** - Buffer, edit, navigation, search, diagnostics, and more
+- **Dual Interface** - Same tool works via MCP and Neovim keymaps/commands
+- **Extensible** - Create custom tools in Lua with simple API
+- **Hot Reload** - Edit tool files, keymaps update automatically
+- **Secure** - Localhost-only by default, Bearer token auth on HTTP endpoints
 
 ## Documentation
 
 - [Installation](installation.md) - Get up and running
 - [Configuration](configuration.md) - Customize behavior
-- [Tools Reference](tools.md) - Built-in tool documentation
+- [Tools Reference](tools.md) - Built-in tool documentation with MCP examples
 - [Creating Tools](creating-tools.md) - Build your own tools

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -111,6 +111,10 @@ Add to your Claude Desktop config:
 
 Connect directly to a specific Neovim instance by URL. Simpler, but you must know the port and can only connect to one session.
 
+!!! note "Auth with direct SSE"
+    With default `auth = true`, direct connections must send `Authorization: Bearer <token>`.
+    If your MCP client cannot send auth headers, use `buddy-mcp-proxy` instead.
+
 #### OpenCode
 
 ```jsonc

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -648,9 +648,9 @@ my_helper/
   plugin/my_helper.lua     -- Commands & keymaps (entry point)
   lua/
     my_helper/
+      buddy.lua            -- MCP tool definition (discovered by buddy.nvim)
       init.lua             -- Public API
       config.lua           -- Configuration with defaults
-    buddy.lua              -- MCP tool definition
 ```
 
 ---

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -50,6 +50,60 @@ Read and list Neovim buffers.
 | `offset` | number | No | Line number to start reading from (0-based). For `get_content` |
 | `limit` | number | No | Number of lines to read (defaults to 2000). For `get_content` |
 
+### MCP Examples
+
+**List all buffers:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "buffer",
+    "arguments": { "action": "list" }
+  }
+}
+```
+
+Response (raw tool return — buddy.nvim wraps this in MCP `content`):
+
+```json
+{
+  "success": true,
+  "buffers": [
+    { "bufnr": 1, "name": "/home/user/project/init.lua", "modified": false, "filetype": "lua" },
+    { "bufnr": 3, "name": "/home/user/project/README.md", "modified": true, "filetype": "markdown" }
+  ]
+}
+```
+
+**Read buffer content with pagination:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "buffer",
+    "arguments": { "action": "get_content", "bufnr": 1, "offset": 0, "limit": 100 }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "bufnr": 1,
+  "name": "/home/user/project/init.lua",
+  "content": "00001| local M = {}\n00002| \n00003| function M.setup()\n...",
+  "line_count": 250,
+  "offset": 0,
+  "limit": 100,
+  "showing": 100,
+  "has_more": true
+}
+```
+
 ---
 
 ## edit
@@ -76,6 +130,70 @@ Edit buffer content.
 - **replace_all**: Replace entire buffer content
 - **replace_match**: Find and replace text (recommended for precise edits)
 
+### MCP Examples
+
+**Find-and-replace text (recommended):**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "edit",
+    "arguments": {
+      "action": "replace_match",
+      "oldString": "local old_var = 1",
+      "newString": "local new_var = 42"
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "action": "replace_match", "replaced": 1 }
+```
+
+**Insert lines at position:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "edit",
+    "arguments": {
+      "action": "insert",
+      "line": 5,
+      "content": "-- New comment\nlocal x = 1"
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "inserted": 2 }
+```
+
+**Delete a line range:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "edit",
+    "arguments": { "action": "delete", "line": 10, "end_line": 15 }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "deleted": 6 }
+```
+
 ---
 
 ## command
@@ -87,6 +205,44 @@ Execute Vim commands.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `cmd` | string | Yes | The Vim command to execute (e.g., `write`, `edit file.txt`, `split`) |
+
+### MCP Examples
+
+**Save the current file:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "command",
+    "arguments": { "cmd": "write" }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "cmd": "write", "output": "\"init.lua\" 42L, 1234B written" }
+```
+
+**Run a Lua expression:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "command",
+    "arguments": { "cmd": "lua vim.fn.getcwd()" }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "cmd": "lua vim.fn.getcwd()", "result": "/home/user/project" }
+```
 
 ---
 
@@ -102,7 +258,7 @@ Navigate Neovim: marks, jumps, and cursor movement.
 | `line` | number | No | Line number (1-indexed) for `goto_line` or `set_mark` |
 | `column` | number | No | Column number (0-indexed) |
 | `file` | string | No | File path for `goto_file` |
-| `mark` | string | No | Mark character (a-z) |
+| `mark` | string | No | Mark character (a-z or A-Z) |
 
 ### Actions
 
@@ -110,11 +266,49 @@ Navigate Neovim: marks, jumps, and cursor movement.
 |--------|-------------|
 | `goto_line` | Jump to line |
 | `goto_file` | Open file |
-| `set_mark` | Set mark |
-| `goto_mark` | Jump to mark |
+| `set_mark` | Set mark (a-z only) |
+| `goto_mark` | Jump to mark (a-z or A-Z) |
 | `jump_back` | Go back in jumplist |
 | `jump_forward` | Go forward in jumplist |
 | `jump_list` | List jumps |
+
+### MCP Examples
+
+**Open a file:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "navigation",
+    "arguments": { "action": "goto_file", "file": "lua/buddy/init.lua" }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "file": "lua/buddy/init.lua" }
+```
+
+**Jump to a line:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "navigation",
+    "arguments": { "action": "goto_line", "line": 42, "column": 0 }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "line": 42, "column": 0 }
+```
 
 ---
 
@@ -133,6 +327,49 @@ Search and replace in current buffer.
 | `ignore_case` | boolean | No | Case insensitive search |
 | `whole_word` | boolean | No | Match whole words only |
 
+### MCP Examples
+
+**Search for a pattern:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "search",
+    "arguments": { "action": "find", "pattern": "TODO", "ignore_case": true }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "pattern": "TODO", "total": 3, "incomplete": false }
+```
+
+**Find and replace:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "search",
+    "arguments": {
+      "action": "find_replace",
+      "pattern": "old_name",
+      "replacement": "new_name",
+      "global": true
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{ "success": true, "pattern": "old_name", "replacement": "new_name", "message": "3 substitutions on 3 lines" }
+```
+
 ---
 
 ## grep
@@ -147,6 +384,39 @@ Project-wide search using vimgrep with quickfix list.
 | `file_pattern` | string | No | File pattern (default: `**/*`) |
 | `path` | string | No | Directory to search in (default: current working directory) |
 
+### MCP Examples
+
+**Search project for a pattern:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "grep",
+    "arguments": { "pattern": "require.*buddy", "file_pattern": "**/*.lua" }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "pattern": "require.*buddy",
+  "file_pattern": "**/*.lua",
+  "matches": [
+    { "filename": "lua/buddy/init.lua", "lnum": 3, "text": "local log = require(\"buddy.log\")" },
+    { "filename": "lua/buddy/config.lua", "lnum": 1, "text": "--- Configuration for buddy" }
+  ],
+  "total": 15,
+  "showing": 10
+}
+```
+
+!!! note "Result limit"
+    Grep returns up to 10 matches in the response. All matches are available in the quickfix list (`:copen`).
+
 ---
 
 ## diagnostics
@@ -158,10 +428,59 @@ Get LSP diagnostics from Neovim.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `bufnr` | number | No | Buffer number. Omit for all buffers, 0 for current |
-| `severity` | `error` \| `warn` \| `info` \| `hint` \| `all` | No | Filter by severity (default: `all`) |
+| `severity` | `error` \| `warning` \| `info` \| `hint` \| `all` | No | Filter by severity (default: `all`) |
 | `path` | string | No | Filter to files matching this path pattern |
-| `scan_dir` | string | No | Directory to scan for files |
+| `scan_dir` | string | No | Directory to scan for files (opens files to trigger LSP) |
 | `pattern` | string | No | Glob pattern for scan_dir (default: `**/*.lua`) |
+
+### MCP Examples
+
+**Get all diagnostics for current buffer:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "diagnostics",
+    "arguments": { "bufnr": 0, "severity": "error" }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "total": 2,
+  "counts": { "error": 2, "warning": 0, "info": 0, "hint": 0 },
+  "files": [
+    {
+      "file": "/home/user/project/init.lua",
+      "count": 2,
+      "diagnostics": [
+        { "line": 10, "col": 5, "severity": "error", "message": "Undefined global `foo`", "source": "Lua Diagnostics.", "code": "undefined-global" },
+        { "line": 25, "col": 12, "severity": "error", "message": "Type mismatch", "source": "Lua Diagnostics." }
+      ]
+    }
+  ]
+}
+```
+
+**Scan a directory for diagnostics:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "diagnostics",
+    "arguments": { "scan_dir": "lua/buddy", "pattern": "**/*.lua", "severity": "error" }
+  }
+}
+```
+
+!!! note "scan_dir behavior"
+    When `scan_dir` is provided, buddy.nvim opens matching files to trigger LSP analysis, waits up to 10 seconds for diagnostics, then returns results. Temporary buffers are wiped after scanning.
 
 ---
 
@@ -308,11 +627,39 @@ Scaffold a new buddy Lua tool with the correct structure.
 | `description` | string | No | Tool description |
 | `path` | string | No | Custom path for tool (default: `stdpath('data')/buddy-tools/`) |
 
+### MCP Example
+
+**Create a new tool:**
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "init",
+    "arguments": { "name": "my_helper", "description": "A custom helper tool" }
+  }
+}
+```
+
+The tool creates a complete plugin structure at `~/.local/share/nvim/buddy-tools/my_helper/` with:
+
+```
+my_helper/
+  plugin/my_helper.lua     -- Commands & keymaps (entry point)
+  lua/
+    my_helper/
+      init.lua             -- Public API
+      config.lua           -- Configuration with defaults
+    buddy.lua              -- MCP tool definition
+```
+
 ---
 
 ## viz
 
 Visualization tool for images, charts, and diagrams.
+
+*Provided by the companion plugin `buddy_viz`.*
 
 ### Parameters
 
@@ -333,6 +680,8 @@ Visualization tool for images, charts, and diagrams.
 
 View all buddy tools and navigate to their source files.
 
+*Provided by the companion plugin `buddy_core`.*
+
 ### Parameters
 
 None.
@@ -342,6 +691,8 @@ None.
 ## dotfyle_search
 
 Search for Neovim plugins on Dotfyle.
+
+*Provided by the companion plugin `buddy_core`.*
 
 ### Parameters
 
@@ -354,6 +705,8 @@ Search for Neovim plugins on Dotfyle.
 ## lazy_manager
 
 Browse and edit lazy.nvim plugin config files.
+
+*Provided by the companion plugin `buddy_core`.*
 
 ### Parameters
 

--- a/lua/buddy/init.lua
+++ b/lua/buddy/init.lua
@@ -236,21 +236,39 @@ function M.call(tool_name, args)
 end
 
 --- Register a tool programmatically
----@param tool table Tool definition with name, description, args, required, and run function
+---@param tool table Tool definition with name, description, run function, and either input_schema or args/required
 ---@param opts? table Optional configuration to pass to the tool
 function M.register_tool(tool, opts)
   if not tool or not tool.name then
     error("Tool must have a name")
   end
-  
+
   local registry = require("buddy.tools")
-  
+
+  local args = tool.args or {}
+  local required = tool.required or {}
+  local input_schema = tool.input_schema
+
+  -- Backward compatibility: synthesize input_schema from legacy args/required
+  -- so tools/list can always expose a discoverable JSON schema.
+  if not input_schema then
+    input_schema = {
+      type = "object",
+      properties = args,
+      required = required,
+    }
+  end
+
   local tool_def = {
     id = tool.name,
     name = tool.name,
     description = tool.description,
-    args = tool.args or {},
-    required = tool.required or {},
+    args = args,
+    required = required,
+    input_schema = input_schema,
+    output_schema = tool.output_schema,
+    title = tool.title,
+    annotations = tool.annotations,
     runtime = "plugin",  -- Mark as plugin-registered (not from tools_dir)
     run = tool.run,
     setup = tool.setup,

--- a/lua/buddy/tools/builtin/init.lua
+++ b/lua/buddy/tools/builtin/init.lua
@@ -42,16 +42,16 @@ return {
     -- Validate name is snake_case
     if not name:match("^[a-z][a-z0-9_]*$") then
       return {
-        isError = true,
-        content = { { type = "text", text = "Invalid name: must be snake_case (lowercase letters, numbers, underscores)" } },
+        success = false,
+        error = "Invalid name: must be snake_case (lowercase letters, numbers, underscores)",
       }
     end
 
     -- Check if already exists
     if vim.fn.isdirectory(dest) == 1 then
       return {
-        isError = true,
-        content = { { type = "text", text = "Tool already exists at: " .. dest } },
+        success = false,
+        error = "Tool already exists at: " .. dest,
       }
     end
 
@@ -61,8 +61,8 @@ return {
 
     if vim.fn.isdirectory(template_dir) == 0 then
       return {
-        isError = true,
-        content = { { type = "text", text = "Template directory not found at: " .. template_dir } },
+        success = false,
+        error = "Template directory not found at: " .. template_dir,
       }
     end
 
@@ -113,19 +113,17 @@ Structure:
     plugin/%s.lua     -- Commands & keymaps (entry point)
     lua/
       %s/
+        buddy.lua     -- MCP tool definition for AI agents
         init.lua      -- Public API (M.setup, M.run, etc.)
         config.lua    -- Configuration with defaults
-      buddy.lua       -- MCP tool definition for AI agents
 
 Next steps:
 1. Add to runtimepath or install via plugin manager
 2. Customize the plugin logic in lua/%s/init.lua
-3. Update MCP schema in lua/buddy.lua if needed]],
-      name, dest, name, name, name, name
+3. Update MCP schema in lua/%s/buddy.lua if needed]],
+      name, dest, name, name, name, name, name
     )
 
-    return {
-      content = { { type = "text", text = msg } },
-    }
+    return { success = true, message = msg, path = dest }
   end,
 }

--- a/lua/buddy/tools/builtin/template/lua/TOOL_NAME/buddy.lua
+++ b/lua/buddy/tools/builtin/template/lua/TOOL_NAME/buddy.lua
@@ -10,14 +10,6 @@
 
 local plugin = require("TOOL_NAME")
 
-local function ok(text)
-  return { content = { { type = "text", text = text or "Success" } } }
-end
-
-local function err(message)
-  return { isError = true, content = { { type = "text", text = message } } }
-end
-
 return {
   name = "TOOL_NAME",
   -- title = "Human-Readable Tool Name",  -- Optional: display name for UI
@@ -36,9 +28,12 @@ return {
   },
   run = function(args)
     local result = plugin.run(args.input)
-    if result.error then
-      return err(result.error)
+    if type(result) == "table" and result.error then
+      error(result.error)
     end
-    return ok(result.message or result)
+    if type(result) == "table" and result.message then
+      return result.message
+    end
+    return result
   end,
 }

--- a/mcp/buddy-mcp-proxy/README.md
+++ b/mcp/buddy-mcp-proxy/README.md
@@ -4,7 +4,7 @@ MCP proxy server for buddy.nvim sessions. This proxy allows OpenCode (or any MCP
 
 ## How it works
 
-1. **Sessions Registry**: Reads buddy.nvim session info from `~/.local/state/buddy/sessions.json` (or `$XDG_STATE_HOME/buddy/sessions.json`)
+1. **Sessions Registry**: Reads buddy.nvim session info from `~/.local/state/nvim/buddy/sessions.json` (or `$XDG_STATE_HOME/nvim/buddy/sessions.json`)
 2. **Meta-tools**: Exposes tools to list, select, and manage sessions
 3. **Tool Proxying**: Once a session is selected, proxies all its tools to the MCP client
 
@@ -93,6 +93,7 @@ Recommended (buddy.nvim):
       "cwd": "/home/user/project-a",
       "label": "project-a",
       "pid": 12345,
+      "auth_token": "<random-bearer-token>",
       "started_at": 1730000000,
       "last_seen": 1730000030
     }


### PR DESCRIPTION
## Summary
- rewrite README tool-authoring section with accurate discovery formats and raw-return guidance
- align `docs/creating-tools.md` with real behavior (no auto-generated action routing) and add clearer result/async guidance
- expand `docs/tools.md` with practical MCP `tools/call` request/response examples for core built-ins
- update docs home/config sections for clearer onboarding and current options (`auth`, `watch`)

## Notes
- README and creating-tools examples now both show multiple tools (`greet` and `farewell`) in the tools-list format.